### PR TITLE
ci: use e2e setup image from ECR

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -4,7 +4,10 @@ executors:
   e2e-executor:
     resource_class: xlarge
     docker: # run the steps with Docker
-      - image: cypress/base:12 # Test steps container
+      - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v1
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
         environment:
           DEFAULT_COMMIT: master
           DOCKER_COMPOSE_VERSION: '1.24.1'


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1849**

### Brief description. What is this change?

Uses hosted container image to install all tooling for e2e tests

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

Pushed the new e2e docker image to ECR and used it in our e2e executor on CircleCI
<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
