### PR TITLE
ci: add command to halt if pull request is draft (VF-2100)

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -2164,6 +2164,7 @@ jobs:
       skip_on_draft:
         description: Skip running e2e for draft PRs
         type: boolean
+        default: false
     steps:
       - when:
           condition: << parameters.skip_on_draft >>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2100**

### Brief description. What is this change?

Adds reusable command that halts the current job if the pull request is a draft

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

This uses the GitHub cli to query whether the pull request in question is a draft.


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
