### PR TITLE
fix: only check PRs for draft status

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -574,13 +574,18 @@ commands:
             command: |
               REPO=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
               PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
-              echo "Checking whether PR $PR_NUMBER is draft"
-              IS_DRAFT=$(gh pr view $PR_NUMBER --repo $REPO --json isDraft --jq '.isDraft')
-              if $IS_DRAFT; then
-                echo "PR $PR_NUMBER is a draft; skipping rest of job"
-                circleci-agent step halt
+
+              if [ -z "$PR_NUMBER" ]; then
+                echo "This job does not target a PR"
               else
-                echo "PR $PR_NUMBER is not a draft; continuing job"
+                echo "Checking whether PR $PR_NUMBER is draft"
+                IS_DRAFT=$(gh pr view $PR_NUMBER --repo $REPO --json isDraft --jq '.isDraft')
+                if $IS_DRAFT; then
+                  echo "PR $PR_NUMBER is a draft; skipping rest of job"
+                  circleci-agent step halt
+                else
+                  echo "PR $PR_NUMBER is not a draft; continuing job"
+                fi
               fi
 
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2100**

### Brief description. What is this change?

[this task](https://app.circleci.com/pipelines/github/voiceflow/creator-app/105486/workflows/7c3aff4d-5029-4469-aea5-78a98017dfaa/jobs/197793) that checks for draft PRs fails when running on the `master` branch

### Implementation details. How do you make this change?

* avoid checking if draft when no PR can be found

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
