### PR TITLE
ci: skip e2e on branches without PRs (VF-2194)

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -576,7 +576,12 @@ commands:
               PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
 
               if [ -z "$PR_NUMBER" ]; then
-                echo "This job does not target a PR"
+                if [ "$CIRCLE_BRANCH" == "master" ]; then
+                  echo "Always run e2e tests on changes to master"
+                else
+                  echo "No PR associated with branch; skipping rest of job"
+                  circleci-agent step halt
+                fi
               else
                 echo "Checking whether PR $PR_NUMBER is draft"
                 IS_DRAFT=$(gh pr view $PR_NUMBER --repo $REPO --json isDraft --jq '.isDraft')


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2194**

### Brief description. What is this change?

This updates the skipping behaviour to skip on all new branches (branches without PRs). This does not risk skipping e2e altogether since all PRs are set to be drafts now.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
