### PR TITLE
ci(tags): trigger CircleCI for tags published in release_monorepo (VF-2167)

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -598,7 +598,7 @@ commands:
     description: Triggers the CircleCI pipeline for every tag in the provided list
     parameters:
       published_tags:
-        description: Environment variable in which to store the list of updated packages
+        description: Environment variable in which to store the list of tags to trigger
         type: env_var_name
     steps:
       - run:

--- a/orb.yml
+++ b/orb.yml
@@ -1,5 +1,15 @@
 version: 2.1
 description: Voiceflow's common CI/CD orb
+
+# Reusable YAML chunks
+defaults:
+  published_packages_env_parameter: &published_packages_env_parameter
+    published_packages:
+      description: Environment variable in which to store the list of updated packages
+      type: env_var_name
+      default: MONOREPO_UPDATED_PACKAGES
+
+
 executors:
   e2e-executor:
     resource_class: xlarge
@@ -592,7 +602,6 @@ commands:
                   echo "PR $PR_NUMBER is not a draft; continuing job"
                 fi
               fi
-
 
 #-------------------------------------------------------------YARN COMMANDS----------------------------------------------------------
   serverless_deploy:
@@ -1804,6 +1813,57 @@ commands:
           run_on_root: << parameters.run_on_root >>
           force_execution: << parameters.force_execution >>
 
+#-------------------------------------------------------------PACKAGE DEPLOYMENT COMMANDS----------------------------------------------------------
+
+  # Asserts that the necessary scripts to perform the deploy are defined
+  # for each package
+  check_packages_deploy_interface:
+    parameters:
+      <<: *published_packages_env_parameter
+    steps:
+      - run:
+          name: Print list of updated packages
+          command: 'echo "Validating packages: ${<< parameters.published_packages >>}"'
+      - run:
+          name: Check that all required commands are present
+          command: 'echo "Validating packages: ${<< parameters.published_packages >>}"'
+
+  deploy_packages:
+    parameters:
+      <<: *published_packages_env_parameter
+    steps:
+      - run:
+          name: Print list of updated packages
+          command: 'echo "Updated packages: ${<< parameters.published_packages >>}"'
+      - check_packages_deploy_interface
+      - build_packages
+      - update_track_packages
+      - build_deploy_package_images
+
+  build_packages:
+    parameters:
+      <<: *published_packages_env_parameter
+    steps:
+      - run:
+          name: Print list of updated packages
+          command: 'echo "Building packages: ${<< parameters.published_packages >>}"'
+
+  update_track_packages:
+    parameters:
+      <<: *published_packages_env_parameter
+    steps:
+      - run:
+          name: Print list of updated packages
+          command: 'echo "Updating package tracks: ${<< parameters.published_packages >>}"'
+
+  build_deploy_package_images:
+    parameters:
+      <<: *published_packages_env_parameter
+    steps:
+      - run:
+          name: Print list of updated packages
+          command: 'echo "Deploying packages: ${<< parameters.published_packages >>}"'
+
 #-------------------------------------------------------------E2E COMMANDS----------------------------------------------------------
 
 
@@ -2084,6 +2144,7 @@ jobs:
   release_monorepo:
     executor: node-executor
     parameters:
+      <<: *published_packages_env_parameter
       install_args:
         description: Additional yarn install command options
         type: string
@@ -2119,6 +2180,7 @@ jobs:
             git config --global user.email "serviceaccount@voiceflow.com"
             git config --global user.name "Voiceflow"
             SENTRY_PROJECT=<< parameters.sentry_project >> HUSKY=0 npx lerna@4.0.0 publish --message "chore(release): publish" --yes --conventional-commits --no-verify-access << parameters.publish_args >>
+      - deploy_packages
 
 #-------------------------------------------------------------E2E----------------------------------------------------------
 

--- a/orb.yml
+++ b/orb.yml
@@ -2099,10 +2099,6 @@ jobs:
   release_monorepo:
     executor: node-executor
     parameters:
-      published_tags:
-        description: Environment variable in which to store the list of updated packages
-        type: env_var_name
-        default: MONOREPO_UPDATED_TAGS
       install_args:
         description: Additional yarn install command options
         type: string
@@ -2138,9 +2134,9 @@ jobs:
             git config --global user.email "serviceaccount@voiceflow.com"
             git config --global user.name "Voiceflow"
             SENTRY_PROJECT=<< parameters.sentry_project >> HUSKY=0 npx lerna@4.0.0 publish --message "chore(release): publish" --yes --conventional-commits --no-verify-access << parameters.publish_args >>
-            echo "export << parameters.published_tags >>=\"$(git tag --points-at HEAD)\"" >> $BASH_ENV
+            echo "export MONOREPO_UPDATED_TAGS=\"$(git tag --points-at HEAD)\"" >> $BASH_ENV
       - trigger_tags_pipelines:
-          published_tags: << parameters.published_tags >>
+          published_tags: MONOREPO_UPDATED_TAGS
 
 #-------------------------------------------------------------E2E----------------------------------------------------------
 

--- a/orb.yml
+++ b/orb.yml
@@ -609,9 +609,12 @@ commands:
       <<: *published_tags_env_parameter
     steps:
       - run:
-        name: Trigger Pipelines for each updated tag
-        command: |
-          echo "Triggering tags: ${<< parameters.published_packages >>}"
+          name: Trigger Pipelines for each updated tag
+          command: |
+             for TAG in ${<< parameters.published_tags >>}
+             do
+               curl -u ${CIRCLECI_API_TOKEN}: -X POST --header 'Content-Type: application/json'  -d "{\"tag\":\"$TAG\", \"parameters\": {}}"  https://circleci.com/api/v2/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pipeline
+             done
 
 #-------------------------------------------------------------YARN COMMANDS----------------------------------------------------------
   serverless_deploy:
@@ -2139,7 +2142,7 @@ jobs:
             git config --global user.email "serviceaccount@voiceflow.com"
             git config --global user.name "Voiceflow"
             SENTRY_PROJECT=<< parameters.sentry_project >> HUSKY=0 npx lerna@4.0.0 publish --message "chore(release): publish" --yes --conventional-commits --no-verify-access << parameters.publish_args >>
-      - deploy_packages
+      - trigger_tags_pipelines
 
 #-------------------------------------------------------------E2E----------------------------------------------------------
 

--- a/orb.yml
+++ b/orb.yml
@@ -3,11 +3,11 @@ description: Voiceflow's common CI/CD orb
 
 # Reusable YAML chunks
 defaults:
-  published_packages_env_parameter: &published_packages_env_parameter
-    published_packages:
+  published_tags_env_parameter: &published_tags_env_parameter
+    published_tags:
       description: Environment variable in which to store the list of updated packages
       type: env_var_name
-      default: MONOREPO_UPDATED_PACKAGES
+      default: MONOREPO_UPDATED_TAGS
 
 
 executors:
@@ -602,6 +602,16 @@ commands:
                   echo "PR $PR_NUMBER is not a draft; continuing job"
                 fi
               fi
+
+  trigger_tags_pipelines:
+    description: Triggers the CircleCI pipeline for every tag in the provided list
+    parameters:
+      <<: *published_tags_env_parameter
+    steps:
+      - run:
+        name: Trigger Pipelines for each updated tag
+        command: |
+          echo "Triggering tags: ${<< parameters.published_packages >>}"
 
 #-------------------------------------------------------------YARN COMMANDS----------------------------------------------------------
   serverless_deploy:
@@ -1813,57 +1823,6 @@ commands:
           run_on_root: << parameters.run_on_root >>
           force_execution: << parameters.force_execution >>
 
-#-------------------------------------------------------------PACKAGE DEPLOYMENT COMMANDS----------------------------------------------------------
-
-  # Asserts that the necessary scripts to perform the deploy are defined
-  # for each package
-  check_packages_deploy_interface:
-    parameters:
-      <<: *published_packages_env_parameter
-    steps:
-      - run:
-          name: Print list of updated packages
-          command: 'echo "Validating packages: ${<< parameters.published_packages >>}"'
-      - run:
-          name: Check that all required commands are present
-          command: 'echo "Validating packages: ${<< parameters.published_packages >>}"'
-
-  deploy_packages:
-    parameters:
-      <<: *published_packages_env_parameter
-    steps:
-      - run:
-          name: Print list of updated packages
-          command: 'echo "Updated packages: ${<< parameters.published_packages >>}"'
-      - check_packages_deploy_interface
-      - build_packages
-      - update_track_packages
-      - build_deploy_package_images
-
-  build_packages:
-    parameters:
-      <<: *published_packages_env_parameter
-    steps:
-      - run:
-          name: Print list of updated packages
-          command: 'echo "Building packages: ${<< parameters.published_packages >>}"'
-
-  update_track_packages:
-    parameters:
-      <<: *published_packages_env_parameter
-    steps:
-      - run:
-          name: Print list of updated packages
-          command: 'echo "Updating package tracks: ${<< parameters.published_packages >>}"'
-
-  build_deploy_package_images:
-    parameters:
-      <<: *published_packages_env_parameter
-    steps:
-      - run:
-          name: Print list of updated packages
-          command: 'echo "Deploying packages: ${<< parameters.published_packages >>}"'
-
 #-------------------------------------------------------------E2E COMMANDS----------------------------------------------------------
 
 
@@ -2144,7 +2103,7 @@ jobs:
   release_monorepo:
     executor: node-executor
     parameters:
-      <<: *published_packages_env_parameter
+      <<: *published_tags_env_parameter
       install_args:
         description: Additional yarn install command options
         type: string

--- a/orb.yml
+++ b/orb.yml
@@ -1,15 +1,6 @@
 version: 2.1
 description: Voiceflow's common CI/CD orb
 
-# Reusable YAML chunks
-defaults:
-  published_tags_env_parameter: &published_tags_env_parameter
-    published_tags:
-      description: Environment variable in which to store the list of updated packages
-      type: env_var_name
-      default: MONOREPO_UPDATED_TAGS
-
-
 executors:
   e2e-executor:
     resource_class: xlarge
@@ -606,7 +597,9 @@ commands:
   trigger_tags_pipelines:
     description: Triggers the CircleCI pipeline for every tag in the provided list
     parameters:
-      <<: *published_tags_env_parameter
+      published_tags:
+        description: Environment variable in which to store the list of updated packages
+        type: env_var_name
     steps:
       - run:
           name: Trigger Pipelines for each updated tag
@@ -2106,7 +2099,10 @@ jobs:
   release_monorepo:
     executor: node-executor
     parameters:
-      <<: *published_tags_env_parameter
+      published_tags:
+        description: Environment variable in which to store the list of updated packages
+        type: env_var_name
+        default: MONOREPO_UPDATED_TAGS
       install_args:
         description: Additional yarn install command options
         type: string
@@ -2142,7 +2138,9 @@ jobs:
             git config --global user.email "serviceaccount@voiceflow.com"
             git config --global user.name "Voiceflow"
             SENTRY_PROJECT=<< parameters.sentry_project >> HUSKY=0 npx lerna@4.0.0 publish --message "chore(release): publish" --yes --conventional-commits --no-verify-access << parameters.publish_args >>
-      - trigger_tags_pipelines
+            echo "export << parameters.published_tags >>=\"$(git tag --points-at HEAD)\"" >> $BASH_ENV
+      - trigger_tags_pipelines:
+          published_tags: << parameters.published_tags >>
 
 #-------------------------------------------------------------E2E----------------------------------------------------------
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2167**

### Brief description. What is this change?

This adds a new command called `trigger_tags_pipelines` that manually triggers the CircleCI pipelines for tags passed through an environment variable. This is used to trigger the pipelines for tags published by lerna as part of the `release_monorepo` step. This is necessary due to the limitations on payload size for GitHub web hooks.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

In order to pass the tags generated as part of the job, an environment variable is used.

Tested:
https://app.circleci.com/pipelines/github/voiceflow/poc-docker-layer-caching/153/workflows/39801740-b9ec-427e-a534-0ffd7965547c/jobs/140
<img width="1157" alt="Screen Shot 2021-11-15 at 4 39 59 PM" src="https://user-images.githubusercontent.com/34867186/141857642-50aac980-4d9b-495e-a126-2630a2ba39ab.png">




### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
