### PR TITLE
fix: attempt local publish after docker login (vf-000)

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -1902,6 +1902,7 @@ commands:
                 version: 20.10.11
       - attach_workspace:
           at: ~/voiceflow
+      - docker_login
       - when:
           condition: << parameters.monorepo_directory >>
           steps:
@@ -1909,7 +1910,6 @@ commands:
                 verdaccio_config: << parameters.monorepo_directory >>/config/verdaccio/config.yaml
             - monorepo_publish_to_local_registry:
                 working_directory: << parameters.monorepo_directory >>
-      - docker_login
       - run:
           name: "Build docker image"
           command: |


### PR DESCRIPTION
### Brief description. What is this change?

Needed to be logged in to `docker` before attempting to pull our private docker image used for the local npm registry.
Basing this off the pattern found in the `update_track` job that works in a similar way

Discovered as a result of [this past change](https://github.com/voiceflow/orb-common/pull/68) failing when attempting to build from the `production` branch of `creator-app`
https://app.circleci.com/pipelines/github/voiceflow/creator-app/121456/workflows/df1778b0-253b-402e-a634-be516334abd8
