### PR TITLE
fix: use local registry during e2e docker build (vf-000)

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -1938,7 +1938,13 @@ commands:
             fi
             echo -e "Building with SEM_VER=$SEM_VER"
             docker build \
-              --build-arg NPM_TOKEN=//registry.npmjs.org/:_authToken=${NPM_TOKEN} \
+              <<# parameters.monorepo_directory >> \
+                --network host \
+                --build-arg build_REGISTRY_URL=http://localhost:4873 \
+              <</ parameters.monorepo_directory >> \
+              <<^ parameters.monorepo_directory >> \
+                --build-arg NPM_TOKEN=//registry.npmjs.org/:_authToken=${NPM_TOKEN} \
+              <</ parameters.monorepo_directory >> \
               --build-arg build_BUILD_NUM=${CIRCLE_BUILD_NUM} \
               --build-arg build_BUILD_URL=${CIRCLE_BUILD_URL}	\
               --build-arg build_GITHUB_TOKEN=${GITHUB_TOKEN} \


### PR DESCRIPTION
### Brief description. What is this change?

Again, similar to `update_track` we need to explicitly pass the local npm registry URL and connect to the host network in order to use the pre-release packages during docker build.
