### PR TITLE
ci: add release action on push to master (IN-306)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
           filters: *dev_filter
       - orb-tools/publish:
           filters: *dev_filter
+          context: dev-test
           requires: [validate-orb]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
@@ -44,6 +45,7 @@ workflows:
           filters: *prod_filter
       - orb-tools/publish:
           filters: *prod_filter
+          context: dev-test
           requires: [validate-orb]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,15 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@10.1.0
+  orb-tools: circleci/orb-tools@11.2.0
   cli: circleci/circleci-cli@0.1.8
 
+prod_filter: &prod_filter
+  tags:
+    only: /.*/
+
+dev_filter: &dev_filter
+  branches:
+    ignore: master
 
 jobs:
   validate-orb:
@@ -17,35 +24,22 @@ workflows:
   publish-dev-orb:
     jobs:
       - validate-orb:
-          filters:
-            branches:
-              ignore: master
-      - orb-tools/publish-dev:
-          checkout: true
-          orb-path: orb.yml
+          filters: *dev_filter
+      - orb-tools/publish:
+          filters: *dev_filter
+          vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
-          publish-token-variable: CIRCLE_TOKEN
-          requires:
-            - validate-orb
-          filters:
-            branches:
-              ignore: master
+          orb-dir: ./
+          pub-type: dev
+
 
   publish-orb:
     jobs:
       - validate-orb:
-          filters:
-              branches:
-                only: master
-      - orb-tools/increment:
-          checkout: true
-          orb-path: orb.yml
-          orb-ref: voiceflow/common
-          publish-token-variable: CIRCLE_TOKEN
-          segment: patch
-          validate: true
-          requires:
-            - validate-orb
-          filters:
-              branches:
-                only: master
+          filters: *prod_filter
+      - orb-tools/publish:
+          filters: *prod_filter
+          vcs-type: << pipeline.project.type >>
+          orb-name: voiceflow/common
+          orb-dir: ./
+          pub-type: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,6 @@ orbs:
   orb-tools: circleci/orb-tools@11.2.0
   cli: circleci/circleci-cli@0.1.8
 
-prod_filter: &prod_filter
-  tags:
-    only: /.*/
-
 jobs:
   validate-orb:
     executor: cli/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,13 @@ jobs:
       - cli/install
       - run:
           command: circleci orb validate orb.yml
+  check-dir:
+    executor: cli/default
+    steps:
+      - attach_workspace:
+          at: '.'
+      - run:
+          command: pwd
 
 workflows:
   publish-dev-orb:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ workflows:
     jobs:
       - validate-orb:
           filters: *dev_filter
+      - check-dir:
+          filters: *dev_filter
       - orb-tools/publish:
           filters: *dev_filter
-          requires: [validate-orb]
+          requires: [validate-orb, check-dir]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           orb-dir: '.'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,10 @@ workflows:
           filters: *dev_filter
       - orb-tools/publish:
           filters: *dev_filter
+          requires: [validate-orb]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
-          orb-dir: ./
+          orb-dir: '.'
           pub-type: dev
 
 
@@ -39,7 +40,8 @@ workflows:
           filters: *prod_filter
       - orb-tools/publish:
           filters: *prod_filter
+          requires: [validate-orb]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
-          orb-dir: ./
+          orb-dir: '.'
           pub-type: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,11 @@ jobs:
       - checkout
       - cli/install
       - run:
-          command: circleci orb validate orb.yml
-  check-dir:
-    executor: cli/default
-    steps:
-      - attach_workspace:
-          at: '.'
-      - run:
-          command: pwd
+          command: ls && circleci orb validate orb.yml
+      - persist_to_workspace:
+          root: '.'
+          paths:
+            - orb.yml
 
 workflows:
   publish-dev-orb:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,6 @@ prod_filter: &prod_filter
   tags:
     only: /.*/
 
-dev_filter: &dev_filter
-  branches:
-    ignore: master
-
 jobs:
   validate-orb:
     executor: cli/default
@@ -26,11 +22,12 @@ jobs:
 
 workflows:
   publish-dev-orb:
+    when:
+      not:
+        equal: [ master, << pipeline.git.branch >> ]
     jobs:
-      - validate-orb:
-          filters: *dev_filter
+      - validate-orb
       - orb-tools/publish:
-          filters: *dev_filter
           context: dev-test
           requires: [validate-orb]
           vcs-type: << pipeline.project.type >>
@@ -40,11 +37,10 @@ workflows:
 
 
   publish-orb:
+    when: << pipeline.git.tag >>
     jobs:
-      - validate-orb:
-          filters: *prod_filter
+      - validate-orb
       - orb-tools/publish:
-          filters: *prod_filter
           context: dev-test
           requires: [validate-orb]
           vcs-type: << pipeline.project.type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,9 @@ workflows:
     jobs:
       - validate-orb:
           filters: *dev_filter
-      - check-dir:
-          filters: *dev_filter
       - orb-tools/publish:
           filters: *dev_filter
-          requires: [validate-orb, check-dir]
+          requires: [validate-orb]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           orb-dir: '.'

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,34 @@
+name: Tag New Release on Push
+
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout the Latest Code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          output-file: false
+          tag-prefix: voiceflow/common@
+          skip-commit: true
+          skip-version-file: true
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part of IN-306**

### Brief description. What is this change?

Adds a GitHub Actions Workflow to create a new release when changes are pushed to master. This follows the rules of semantic commits, so not all commits will create a new release.

Also updates the CircleCI config to use the new publish command to publish on release.