### PR TITLE
fix: fix orb deployment with tags (IN-302)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,11 @@ workflows:
   publish-orb:
     when: << pipeline.git.tag >>
     jobs:
-      - pack
+      - pack:
+          # Filter required due to CircleCI behaviour described here: https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5
+          filters:
+            tags:
+              only: ['/.*/']
       - orb-tools/publish:
           context: dev-test
           requires: [pack]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# orb.yml is "packed" from source, and not published directly from the repository.
+orb.yml
+.DS_Store


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-302**

### Brief description. What is this change?

Due to an unintuitive behaviour in CircleCI described [here](https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5), at least one of the jobs in the workflow must filter on tags for CircleCI to trigger based on a tag push.

Also adds a .gitignore

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
