### PR TITLE
chore: refactor orb deployment to use pre-steps (IN-303)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
     when: << pipeline.git.tag >>
     jobs:
       - orb-tools/pack:
-          <<: *tags_filters
+          <<: *tags_filter
           pre-steps:
             - <<: *extract_sections_from_subdirectories
       - orb-tools/publish:
@@ -51,4 +51,4 @@ workflows:
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: production
-          <<: *tags_filters
+          <<: *tags_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,8 @@ orbs:
 
 # Filter required due to CircleCI behaviour described here: https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5
 tags_filter: &tags_filter
-  filters:
-    tags:
-      only: ['/.*/']
+  tags:
+    only: ['/.*/']
 
 # Copies configs from their respective subdirectories into
 # the appropriate root directories before packing
@@ -43,7 +42,7 @@ workflows:
     when: << pipeline.git.tag >>
     jobs:
       - orb-tools/pack:
-          <<: *tags_filter
+          filters: *tags_filter
           pre-steps: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
@@ -51,4 +50,4 @@ workflows:
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: production
-          <<: *tags_filter
+          filters: *tags_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
     when: << pipeline.git.tag >>
     jobs:
       - orb-tools/pack:
-          <<: *tag_filters
+          <<: *tags_filters
           pre-steps:
             - <<: *extract_sections_from_subdirectories
       - orb-tools/publish:
@@ -51,4 +51,4 @@ workflows:
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: production
-          <<: *tag_filters
+          <<: *tags_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@11.2.0
-  cli: circleci/circleci-cli@0.1.9
 
 workflows:
   publish-dev-orb:
@@ -9,7 +8,9 @@ workflows:
       not:
         equal: [ master, << pipeline.git.branch >> ]
     jobs:
-      - pack
+      - orb-tools/pack:
+          pre-steps:
+            - <<: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
           requires: [pack]
@@ -21,44 +22,33 @@ workflows:
   publish-orb:
     when: << pipeline.git.tag >>
     jobs:
-      - pack:
-          # Filter required due to CircleCI behaviour described here: https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5
-          filters:
-            tags:
-              only: ['/.*/']
+      - orb-tools/pack:
+          <<: *tag_filters
+          pre-steps:
+            - <<: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
           requires: [pack]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: production
-          filters:
-            tags:
-              only: ['/.*/']
+          <<: *tag_filters
 
 
-jobs:
-  pack:
-    executor: cli/default
-    steps:
-      - checkout
-      - run:
-          # Copies configs from their respective subdirectories into
-          # the appropriate root directories before packing
-          # Necessary because of https://github.com/CircleCI-Public/circleci-cli/issues/755
-          name: Copy configuration from subdirectories
-          command: |
-            for DIR in commands jobs executors examples; do
-              # Copy all files in all subdirectories into orb-src
-              find src/$DIR -type f -exec mv {} src/$DIR \; || :
-            done;
-      - run:
-          name: Pack
-          command: mkdir ./dist && circleci orb pack --skip-update-check src > ./dist/orb.yml
-      - run:
-          name: Validate
-          command: circleci orb validate --skip-update-check ./dist/orb.yml
-      - persist_to_workspace:
-          root: ./dist/
-          paths:
-            - orb.yml
+
+# Filter required due to CircleCI behaviour described here: https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5
+tags_filter: &tags_filter
+  filters:
+    tags:
+      only: ['/.*/']
+
+# Copies configs from their respective subdirectories into
+# the appropriate root directories before packing
+# Necessary because of https://github.com/CircleCI-Public/circleci-cli/issues/755
+run: &extract_sections_from_subdirectories
+  name: Copy configuration from subdirectories
+  command: |
+    for DIR in commands jobs executors examples; do
+      # Copy all files in all subdirectories into orb-src
+      find src/$DIR -type f -exec mv {} src/$DIR \; || :
+    done;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,14 @@ tags_filter: &tags_filter
 # Copies configs from their respective subdirectories into
 # the appropriate root directories before packing
 # Necessary because of https://github.com/CircleCI-Public/circleci-cli/issues/755
-run: &extract_sections_from_subdirectories
-  name: Copy configuration from subdirectories
-  command: |
-    for DIR in commands jobs executors examples; do
-      # Copy all files in all subdirectories into orb-src
-      find src/$DIR -type f -exec mv {} src/$DIR \; || :
-    done;
+extract_sections_from_subdirectories: &extract_sections_from_subdirectories
+  run:
+    name: Copy configuration from subdirectories
+    command: |
+      for DIR in commands jobs executors examples; do
+        # Copy all files in all subdirectories into orb-src
+        find src/$DIR -type f -exec mv {} src/$DIR \; || :
+      done;
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,25 @@ version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@11.2.0
 
+
+# Filter required due to CircleCI behaviour described here: https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5
+tags_filter: &tags_filter
+  filters:
+    tags:
+      only: ['/.*/']
+
+# Copies configs from their respective subdirectories into
+# the appropriate root directories before packing
+# Necessary because of https://github.com/CircleCI-Public/circleci-cli/issues/755
+run: &extract_sections_from_subdirectories
+  name: Copy configuration from subdirectories
+  command: |
+    for DIR in commands jobs executors examples; do
+      # Copy all files in all subdirectories into orb-src
+      find src/$DIR -type f -exec mv {} src/$DIR \; || :
+    done;
+
+
 workflows:
   publish-dev-orb:
     when:
@@ -33,22 +52,3 @@ workflows:
           orb-name: voiceflow/common
           pub-type: production
           <<: *tag_filters
-
-
-
-# Filter required due to CircleCI behaviour described here: https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/5
-tags_filter: &tags_filter
-  filters:
-    tags:
-      only: ['/.*/']
-
-# Copies configs from their respective subdirectories into
-# the appropriate root directories before packing
-# Necessary because of https://github.com/CircleCI-Public/circleci-cli/issues/755
-run: &extract_sections_from_subdirectories
-  name: Copy configuration from subdirectories
-  command: |
-    for DIR in commands jobs executors examples; do
-      # Copy all files in all subdirectories into orb-src
-      find src/$DIR -type f -exec mv {} src/$DIR \; || :
-    done;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,14 @@ tags_filter: &tags_filter
 # the appropriate root directories before packing
 # Necessary because of https://github.com/CircleCI-Public/circleci-cli/issues/755
 extract_sections_from_subdirectories: &extract_sections_from_subdirectories
-  run:
-    name: Copy configuration from subdirectories
-    command: |
-      for DIR in commands jobs executors examples; do
-        # Copy all files in all subdirectories into orb-src
-        find src/$DIR -type f -exec mv {} src/$DIR \; || :
-      done;
+  - checkout
+  - run:
+      name: Copy configuration from subdirectories
+      command: |
+        for DIR in commands jobs executors examples; do
+          # Copy all files in all subdirectories into orb-src
+          find src/$DIR -type f -exec mv {} src/$DIR \; || :
+        done;
 
 
 workflows:
@@ -29,8 +30,7 @@ workflows:
         equal: [ master, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack:
-          pre-steps:
-            - <<: *extract_sections_from_subdirectories
+          pre-steps: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
           requires: [orb-tools/pack]
@@ -44,8 +44,7 @@ workflows:
     jobs:
       - orb-tools/pack:
           <<: *tags_filter
-          pre-steps:
-            - <<: *extract_sections_from_subdirectories
+          pre-steps: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
           requires: [orb-tools/pack]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ workflows:
             - <<: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
-          requires: [pack]
+          requires: [orb-tools/pack]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: dev
@@ -47,7 +47,7 @@ workflows:
             - <<: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
-          requires: [pack]
+          requires: [orb-tools/pack]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: production


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-303**

### Brief description. What is this change?

Refactors deployment code to use pre-steps to extract orb sections from subdirectories.

This means that we no longer need to manually call the pack and validate commands.

We also extract the tags filter for clean reuse
