### PR TITLE
feat: add yarn 3 auth to install_and_build (DX-64)

### DIFF
--- a/src/commands/yarn/authenticate_yarn.yml
+++ b/src/commands/yarn/authenticate_yarn.yml
@@ -1,0 +1,16 @@
+parameters:
+  working_directory:
+    description: Directory containing package.json
+    type: string
+    default: './'
+  run_in_background:
+    description: run the command in background
+    type: boolean
+    default: false
+steps:
+  - run:
+      working_directory: << parameters.working_directory >>
+      background: << parameters.run_in_background >>
+      name: authenticate yarn
+      command: |
+        echo "npmRegistries:\n  \"https://registry.yarnpkg.com\":\n    npmAuthToken: $NPM_TOKEN" >> ~/.yarnrc.yml

--- a/src/commands/yarn/install_node_modules.yml
+++ b/src/commands/yarn/install_node_modules.yml
@@ -44,6 +44,7 @@ parameters:
     type: string
     default: ""
 steps:
+  - authenticate_yarn
   - authenticate_npm
   - vf_restore_cache:
       yarn_lock_restore_cache_directory: << parameters.yarn_lock_restore_cache_directory >>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-64**

### Brief description. What is this change?

Add support for authenticating yarn 3 to install our private packages

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
