### PR TITLE
fix: add yarn3 auth for authenticate npm command (IN-378)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
           pre-steps: *extract_sections_from_subdirectories
       - orb-tools/publish:
           context: dev-test
-          requires: [orb-tools/pack]
+          requires: [orb-tools/pack, orb-tools/lint]
           vcs-type: << pipeline.project.type >>
           orb-name: voiceflow/common
           pub-type: production

--- a/src/commands/yarn/authenticate_npm.yml
+++ b/src/commands/yarn/authenticate_npm.yml
@@ -12,4 +12,4 @@ steps:
       working_directory: << parameters.working_directory >>
       background: << parameters.run_in_background >>
       name: authenticate npm
-      command: <<include(scripts/yarn/authenticate_npm.sh)>>
+      command: <<include(scripts/yarn/authenticate-npm.sh)>>

--- a/src/commands/yarn/authenticate_npm.yml
+++ b/src/commands/yarn/authenticate_npm.yml
@@ -12,4 +12,12 @@ steps:
       working_directory: << parameters.working_directory >>
       background: << parameters.run_in_background >>
       name: authenticate npm
-      command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      command: |
+        echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+        << EOF > ~/.yarnrc.yml
+        npmRegistries:
+          "https://registry.yarnpkg.com":
+            npmAuthToken: $NPM_TOKEN
+          "https://registry.npmjs.org":
+            npmAuthToken: $NPM_TOKEN
+        EOF

--- a/src/commands/yarn/authenticate_npm.yml
+++ b/src/commands/yarn/authenticate_npm.yml
@@ -12,12 +12,4 @@ steps:
       working_directory: << parameters.working_directory >>
       background: << parameters.run_in_background >>
       name: authenticate npm
-      command: |
-        echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-        << EOF > ~/.yarnrc.yml
-        npmRegistries:
-          "https://registry.yarnpkg.com":
-            npmAuthToken: $NPM_TOKEN
-          "https://registry.npmjs.org":
-            npmAuthToken: $NPM_TOKEN
-        EOF
+      command: <<include(scripts/yarn/authenticate_npm.sh)>>

--- a/src/scripts/yarn/authenticate-npm.sh
+++ b/src/scripts/yarn/authenticate-npm.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+cat << EOF > ~/.yarnrc.yml
+npmRegistries:
+    "https://registry.yarnpkg.com":
+    npmAuthToken: $NPM_TOKEN
+    "https://registry.npmjs.org":
+    npmAuthToken: $NPM_TOKEN
+EOF

--- a/src/scripts/yarn/authenticate-npm.sh
+++ b/src/scripts/yarn/authenticate-npm.sh
@@ -3,8 +3,8 @@
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 cat << EOF > ~/.yarnrc.yml
 npmRegistries:
-    "https://registry.yarnpkg.com":
+  "https://registry.yarnpkg.com":
     npmAuthToken: $NPM_TOKEN
-    "https://registry.npmjs.org":
+  "https://registry.npmjs.org":
     npmAuthToken: $NPM_TOKEN
 EOF


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-378**

### Brief description. What is this change?

Use the `.yarnrc.yml` to authenticate Yarn 3
