### PR TITLE
ci: run monorepo commands on bors branches (IN-381)

### DIFF
--- a/src/commands/monorepo/monorepo_exec_command.yml
+++ b/src/commands/monorepo/monorepo_exec_command.yml
@@ -33,7 +33,7 @@ steps:
           echo "Packages found on $i: $PACAKGES"
           for f in $PACAKGES; do
             echo "Checking package $f"
-            if [[ $FILES_CHANGED == *"$f"* || $CIRCLE_BRANCH == "master" || $CIRCLE_BRANCH == "production" || ! -z "$CIRCLE_TAG" || $FORCE_EXECUTION == true  ]]; then
+            if [[ $FILES_CHANGED == *"$f"* || $CIRCLE_BRANCH == "master" || $CIRCLE_BRANCH == "production" || $CIRCLE_BRANCH == "staging" || $CIRCLE_BRANCH == "trying" || ! -z "$CIRCLE_TAG" || $FORCE_EXECUTION == true  ]]; then
                 # Work only on folders that are real packages
                 if [[ -d $f ]]; then
                   if [[ $RUN_ON_ROOT != true ]]; then


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-381**

### Brief description. What is this change?

Tests were being skipped in staging and then failing on master. This runs those tests on staging.