### PR TITLE
feat: add extra args for db init (vf-000)

### DIFF
--- a/src/commands/e2e_setup/setup_vf_dbs_docker.yml
+++ b/src/commands/e2e_setup/setup_vf_dbs_docker.yml
@@ -25,6 +25,10 @@ parameters:
     description: Additional database init command options
     type: string
     default: ""
+  pre_init_steps:
+    description: Steps to be run before the database init command
+    type: steps
+    default: []
 steps:
   - clone_repo:
       step_name: "Clone database-cli repository"
@@ -37,6 +41,7 @@ steps:
       working_directory: << parameters.working_directory >>
       yarn_lock_restore_cache_directory: << parameters.working_directory >>
       cache_prefix: << parameters.cache_prefix >>
+  - steps: << parameters.pre_init_steps >>
   - when:
       condition: << parameters.initialize_database >>
       steps:

--- a/src/commands/e2e_setup/setup_vf_dbs_docker.yml
+++ b/src/commands/e2e_setup/setup_vf_dbs_docker.yml
@@ -20,7 +20,11 @@ parameters:
   working_directory:
     description: Directory containing package.json
     type: string
-    default: '~/database-cli'
+    default: "~/database-cli"
+  database_init_extra_args:
+    description: Additional database init command options
+    type: string
+    default: ""
 steps:
   - clone_repo:
       step_name: "Clone database-cli repository"
@@ -40,4 +44,4 @@ steps:
             name: Setup Database
             working_directory: << parameters.working_directory >>
             command: |
-              yarn init:e2e
+              yarn init:e2e << parameters.database_init_extra_args >>

--- a/src/commands/e2e_setup/setup_vf_dbs_docker.yml
+++ b/src/commands/e2e_setup/setup_vf_dbs_docker.yml
@@ -21,6 +21,10 @@ parameters:
     description: Directory containing package.json
     type: string
     default: "~/database-cli"
+  environment:
+    description: Environment to initialize the databases for
+    type: string
+    default: e2e
   database_init_extra_args:
     description: Additional database init command options
     type: string
@@ -49,4 +53,4 @@ steps:
             name: Setup Database
             working_directory: << parameters.working_directory >>
             command: |
-              yarn init:e2e << parameters.database_init_extra_args >>
+              yarn init:<< parameters.environment >> << parameters.database_init_extra_args >>


### PR DESCRIPTION
### Brief description. What is this change?

Allowing extra args to be passed to database init command so that it can be used to simplify [the config here](https://github.com/voiceflow/platform/blob/master/.circleci/continue-config.yml#L173)

[tested successfully](https://github.com/voiceflow/platform/pull/199/commits/084b8463200c45bb6633bc6d3c3d9d67eb9d2d45)

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
