### PR TITLE
fix: s3 bash condition (CT-000)

### DIFF
--- a/src/scripts/aws/clone_s3_assets.sh
+++ b/src/scripts/aws/clone_s3_assets.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $CLEAN_DESTINATION ]]; then
+if [[ $CLEAN_DESTINATION == true ]]; then
     aws s3 sync $FROM $TO --delete
 else
     aws s3 sync $FROM $TO


### PR DESCRIPTION
Bash needs an explicit `== true` to resolve booleans. Otherwise `export X=false` will result in `if [[ $X ]]; then` being "true".

You can test this in your terminal with a simple script:
```
if [[ $TEST ]]; then
    echo "Test is true"
else
    echo "Test is false"
fi
```

then run `export TEST=false` and `./test.sh` will result in `"Test is true"`

<img width="240" alt="Screen Shot 2022-11-05 at 12 02 42 AM" src="https://user-images.githubusercontent.com/5643574/200100073-5e39059b-7195-408d-be2a-2c5ea4f9c22a.png">

There are no booleans in bash - just strings and numbers. So it's really just a string that says "false"
https://alexopensource.wordpress.com/2021/03/11/there-are-no-booleans-in-bash-commands/
