### PR TITLE
fix: set sem_ver with latest tag created

### DIFF
--- a/src/commands/docker/build_push_image.yml
+++ b/src/commands/docker/build_push_image.yml
@@ -6,7 +6,7 @@ parameters:
     description: The container image tag
     type: string
     default: ""
-  sem_ver:
+  sem_ver_override:
     description: Semantic release version of the package
     type: string
     default: ""
@@ -79,7 +79,7 @@ steps:
   - run:
       name: "Build docker image"
       command: |
-        SEM_VER_OVERRIDE="<< parameters.sem_ver >>"
+        SEM_VER_OVERRIDE="<< parameters.sem_ver_override >>"
         IMAGE_TAG_OVERRIDE="<< parameters.image_tag >>"
         if [[ "$IMAGE_TAG_OVERRIDE" == "" ]]; then
           IMAGE_TAG="k8s-$CIRCLE_SHA1"

--- a/src/commands/docker/build_push_image.yml
+++ b/src/commands/docker/build_push_image.yml
@@ -104,8 +104,8 @@ steps:
           SEM_VER=$CIRCLE_BRANCH-$CIRCLE_SHA1
         fi
 
-        if [[ "$SEM_VER_OVERRIDES" != "" ]]; then
-          SEM_VER=$SEM_VER_OVERRIDES
+        if [[ "$SEM_VER_OVERRIDE" != "" ]]; then
+          SEM_VER=$SEM_VER_OVERRIDE
         fi
 
         if [[ ! -f "$BUILD_CONTEXT/yarn.lock" && -f "yarn.lock" ]]; then

--- a/src/commands/docker/build_push_image.yml
+++ b/src/commands/docker/build_push_image.yml
@@ -87,7 +87,7 @@ steps:
         BUILD_CONTEXT="<< parameters.build_context >>"
 
         # Semantic release from the current tags
-        if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "production" ]]; then
+        if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "production" && ! -z "$CIRCLE_TAG" ]]; then
             # Update the new tags
             git fetch --tags
             SEM_VER=$(git describe --abbrev=0 --tags)

--- a/src/commands/docker/build_push_image.yml
+++ b/src/commands/docker/build_push_image.yml
@@ -6,6 +6,10 @@ parameters:
     description: The container image tag
     type: string
     default: ""
+  sem_ver:
+    description: Semantic release version of the package
+    type: string
+    default: ""
   dockerfile:
     description: Name of the Dockerfile to build
     type: string
@@ -75,6 +79,7 @@ steps:
   - run:
       name: "Build docker image"
       command: |
+        SEM_VER_OVERRIDE="<< parameters.sem_ver >>"
         IMAGE_TAG_OVERRIDE="<< parameters.image_tag >>"
         if [[ "$IMAGE_TAG_OVERRIDE" == "" ]]; then
           IMAGE_TAG="k8s-$CIRCLE_SHA1"
@@ -97,6 +102,10 @@ steps:
           fi
         else
           SEM_VER=$CIRCLE_BRANCH-$CIRCLE_SHA1
+        fi
+
+        if [[ "$SEM_VER_OVERRIDES" != "" ]]; then
+          SEM_VER=$SEM_VER_OVERRIDES
         fi
 
         if [[ ! -f "$BUILD_CONTEXT/yarn.lock" && -f "yarn.lock" ]]; then

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -10,14 +10,6 @@ parameters:
   image_repo:
     description: The container image repository
     type: string
-  install_args:
-    description: Additional yarn install command options
-    type: string
-    default: ""
-  avoid_post_install_scripts:
-    description: Skip running post install scripts
-    type: boolean
-    default: true
   bucket:
     description: The container image repository
     type: string
@@ -31,20 +23,15 @@ steps:
       component: << parameters.component >>
   - attach_workspace:
       at: ~/voiceflow
-  - install_node_modules:
-      install_args: "<< parameters.install_args >>"
-      avoid_post_install_scripts: "<< parameters.avoid_post_install_scripts >>"
   - run:
       name: Update Track
       command: |
         # Load TRACK_EXISTS variable from file previously stored in the tmp folder
         source "/tmp/TRACK_STATUS"
 
-        set +e  # Don't exit on the any error (for semantic-release)
-        npx semantic-release@17 | tee sem_release.output  # print semver to screen and force return 0
-        SEM_VER=$(cat sem_release.output | grep 'The next release version is' | awk '{print $NF}')  # Get release semver
-        echo "Next version is going to be: ${SEM_VER}"
-        set -e  # Don't exit on the any error (for semantic-release)
+        # Update the new tags
+        git fetch --tags
+        SEM_VER=$(git describe --abbrev=0 --tags)
 
         if [[ $TRACK_EXISTS == "true"  && ! -z "$SEM_VER" ]]; then
           # update the track

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -10,6 +10,14 @@ parameters:
   image_repo:
     description: The container image repository
     type: string
+  install_args:
+    description: Additional yarn install command options
+    type: string
+    default: ""
+  avoid_post_install_scripts:
+    description: Skip running post install scripts
+    type: boolean
+    default: true
   bucket:
     description: The container image repository
     type: string
@@ -23,6 +31,9 @@ steps:
       component: << parameters.component >>
   - attach_workspace:
       at: ~/voiceflow
+  - install_node_modules:
+      install_args: "<< parameters.install_args >>"
+      avoid_post_install_scripts: "<< parameters.avoid_post_install_scripts >>"
   - run:
       name: Update Track
       command: |

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -32,6 +32,7 @@ steps:
         # Update the new tags
         git fetch --tags
         SEM_VER=$(git describe --abbrev=0 --tags)
+        echo "New version published: ${SEM_VER}"
 
         if [[ $TRACK_EXISTS == "true"  && ! -z "$SEM_VER" ]]; then
           # update the track
@@ -44,9 +45,9 @@ steps:
         fi
 
         echo "export TAG=${SEM_VER}" >> $BASH_ENV
-        echo "export NEXT_VERSION=${SEM_VER}" >> $BASH_ENV
+        echo "export NEW_VERSION=${SEM_VER}" >> $BASH_ENV
 
   - build_push_image:
       image_repo: << parameters.image_repo >>
       image_tag: "${TAG}"
-      sem_ver: "${NEXT_VERSION}"
+      sem_ver: "${NEW_VERSION}"

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -32,6 +32,7 @@ steps:
         set +e  # Don't exit on the any error (for semantic-release)
         npx semantic-release@17 | tee sem_release.output  # print semver to screen and force return 0
         SEM_VER=$(cat sem_release.output | grep 'The next release version is' | awk '{print $NF}')  # Get release semver
+        echo "Next version is going to be: ${SEM_VER}"
         set -e  # Don't exit on the any error (for semantic-release)
 
         if [[ $TRACK_EXISTS == "true"  && ! -z "$SEM_VER" ]]; then
@@ -45,9 +46,9 @@ steps:
         fi
 
         echo "export TAG=${SEM_VER}" >> $BASH_ENV
-        echo "export SEM_VER=${SEM_VER}" >> $BASH_ENV
+        echo "export NEXT_VERSION=${SEM_VER}" >> $BASH_ENV
 
   - build_push_image:
       image_repo: << parameters.image_repo >>
       image_tag: "${TAG}"
-      sem_ver: "${SEM_VER}"
+      sem_ver: "${NEXT_VERSION}"

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -50,4 +50,4 @@ steps:
   - build_push_image:
       image_repo: << parameters.image_repo >>
       image_tag: "${TAG}"
-      sem_ver: "${NEW_VERSION}"
+      sem_ver_override: "${NEW_VERSION}"

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -7,6 +7,9 @@ parameters:
     description: Determines if a checkout will be executed or not
     type: boolean
     default: true
+  image_repo:
+    description: The container image repository
+    type: string
   bucket:
     description: The container image repository
     type: string
@@ -27,7 +30,7 @@ steps:
         source "/tmp/TRACK_STATUS"
 
         set +e  # Don't exit on the any error (for semantic-release)
-        npx semantic-release@17 --prepare --dry-run | tee sem_release.output  # print semver to screen and force return 0
+        npx semantic-release@17 | tee sem_release.output  # print semver to screen and force return 0
         SEM_VER=$(cat sem_release.output | grep 'The next release version is' | awk '{print $NF}')  # Get release semver
         set -e  # Don't exit on the any error (for semantic-release)
 
@@ -40,3 +43,11 @@ steps:
         else
           echo "Track does not exist! avoiding update!"
         fi
+
+        echo "export TAG=${SEM_VER}" >> $BASH_ENV
+        echo "export SEM_VER=${SEM_VER}" >> $BASH_ENV
+
+  - build_push_image:
+      image_repo: << parameters.image_repo >>
+      image_tag: "${TAG}"
+      sem_ver: "${SEM_VER}"

--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -22,3 +22,9 @@ steps:
   - run:
       name: Release Package
       command: "SENTRY_PROJECT=<< parameters.sentry_project >> npx semantic-release@17\n"
+  - persist_to_workspace:
+      root: "."
+      paths:
+        - ./*.tgz
+  - store_artifacts:
+      path: ./*.tgz

--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -22,9 +22,3 @@ steps:
   - run:
       name: Release Package
       command: "SENTRY_PROJECT=<< parameters.sentry_project >> npx semantic-release@17\n"
-  - persist_to_workspace:
-      root: "."
-      paths:
-        - ./*.tgz
-  - store_artifacts:
-      path: ./*.tgz

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -6,17 +6,7 @@ parameters:
   image_repo:
     description: The container image repository
     type: string
-  install_args:
-    description: Additional yarn install command options
-    type: string
-    default: ""
-  avoid_post_install_scripts:
-    description: Skip running post install scripts
-    type: boolean
-    default: true
 steps:
   - update_database_track:
       component: "<< parameters.component >>"
       image_repo: "<< parameters.image_repo >>"
-      install_args: "<< parameters.install_args >>"
-      avoid_post_install_scripts: "<< parameters.avoid_post_install_scripts >>"

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -6,7 +6,17 @@ parameters:
   image_repo:
     description: The container image repository
     type: string
+  install_args:
+    description: Additional yarn install command options
+    type: string
+    default: ""
+  avoid_post_install_scripts:
+    description: Skip running post install scripts
+    type: boolean
+    default: true
 steps:
   - update_database_track:
       component: "<< parameters.component >>"
       image_repo: "<< parameters.image_repo >>"
+      install_args: "<< parameters.install_args >>"
+      avoid_post_install_scripts: "<< parameters.avoid_post_install_scripts >>"

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -3,6 +3,10 @@ parameters:
   component:
     description: The component type for development environment deployment
     type: string
+  image_repo:
+    description: The container image repository
+    type: string
 steps:
   - update_database_track:
       component: "<< parameters.component >>"
+      image_repo: "<< parameters.image_repo >>"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

If a tag is created or we are running the docker push image on a tag, the SEM_VER variable should be the latest created too.

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
