### PR TITLE
fix: fix helm package publishing (IN-305)

### DIFF
--- a/src/scripts/helm/package-publish-charts.sh
+++ b/src/scripts/helm/package-publish-charts.sh
@@ -6,8 +6,7 @@ for file in */ ; do
         cd "$file" || exit;
         helm dep update "$file";
         helm package "$file";
-        zipfiles=$(find . -type f -name "*.tgz")
-        chart=$(echo $zipfiles | head -n1);
+        chart=$(find . -type f -name "*.tgz" -maxdepth 1); # There should only be one such file in the directory
         channel=$(yq -r '.annotations."release-repository"' "$file"/Chart.yaml)
         echo "publishing in $channel channel";
         if [[ $channel == "private" ]]; then

--- a/src/scripts/helm/package-publish-charts.sh
+++ b/src/scripts/helm/package-publish-charts.sh
@@ -6,7 +6,8 @@ for file in */ ; do
         cd "$file" || exit;
         helm dep update "$file";
         helm package "$file";
-        chart=$(find . -type f -name "*.tgz" | head -n1);
+        zipfiles=$(find . -type f -name "*.tgz")
+        chart=$(echo $zipfiles | head -n1);
         channel=$(yq -r '.annotations."release-repository"' "$file"/Chart.yaml)
         echo "publishing in $channel channel";
         if [[ $channel == "private" ]]; then


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-305**

### Brief description. What is this change?

Fix the SIGPIPE from `find` in helm publishing

### Details

This issue is subtle, but stems from `head -n1` closing its reading pipe while `find` is continuing to produce output. By setting `maxdepth` to `1`, this ensures we only find the one file we want

[IN-305]: https://voiceflow.atlassian.net/browse/IN-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ