### PR TITLE
feat: extract exec monorepo command (IN-304)

### DIFF
--- a/src/commands/monorepo/monorepo_exec_command.yml
+++ b/src/commands/monorepo/monorepo_exec_command.yml
@@ -30,30 +30,8 @@ steps:
       steps:
         - run:
             name: << parameters.step_name >>
-            command: |
-              FILES_CHANGED=$(git diff HEAD^ --name-only )
-              echo "files changed: $FILES_CHANGED"
-              FORCE_EXECUTION=<< parameters.force_execution >>
+            environment:
+              FORCE_EXECUTION: << parameters.force_execution >>
+              COMMAND: '<< parameters.command >> << parameters.extra_args >>'
+            command: <<include(scripts/monorepo/exec_command.sh)>>
 
-              jq -rc '.workspaces[]' package.json | while read i; do
-                # Find all packages down a pacakge root directory. for example packages/*, apps/*, types/*
-                PACKAGES=$(find . -maxdepth 2 -wholename "./$i")
-                echo "Packages found on $i: $PACKAGES"
-                for f in $PACKAGES; do
-                  # The find command add the ./ We dont need it. This command removes it by removing the first 2 characters.
-                  package=$(echo "${f:2}")
-                  echo "Checking package $package"
-                  if [[ $FILES_CHANGED == *"$package"* || " master production staging trying " =~ .*\ $CIRCLE_BRANCH\ .* || ! -z "$CIRCLE_TAG" || $FORCE_EXECUTION == true  ]]; then
-                      # Work only on folders that are real packages
-                      if [[ -d $f ]]; then
-                        cd $f
-                        echo "running command << parameters.command >> on $package"
-
-                        # Execute command
-                        << parameters.command >> << parameters.extra_args >>
-
-                        cd -
-                      fi
-                  fi
-                done
-              done

--- a/src/commands/monorepo/monorepo_exec_command_when_package_changed.yml
+++ b/src/commands/monorepo/monorepo_exec_command_when_package_changed.yml
@@ -26,29 +26,22 @@ parameters:
     type: string
     default: "packages"
 steps:
-  - run:
-      name: << parameters.step_name >>
-      command: |
-        FILES_CHANGED=$(git diff HEAD^ --name-only )
-        echo "files changed: $FILES_CHANGED"
-        PACKAGE_FORCED=<< parameters.package_to_force_execution >>
-        RUN_ON_ROOT=<< parameters.run_on_root >>
-        FORCE_EXECUTION=<< parameters.force_execution >>
-        PACKAGE_FOLDER=<< parameters.package_folder >>
+  - when:
+      condition: << parameters.run_on_root >>
+      steps:
+        - run:
+            name: << parameters.step_name >>
+            command: << parameters.command >> << parameters.extra_parameters >>
+  - unless:
+      condition: << parameters.run_on_root >>
+      steps:
+        - run:
+          name: << parameters.step_name >>
+          working_directory: '<< parameters.package_folder >>/<< parameters.package_to_force_execution >>'
+          command: |
+            FILES_CHANGED=$(git diff HEAD^ --name-only )
+            echo "files changed: $FILES_CHANGED"
 
-        if [[ $FILES_CHANGED == *"$PACKAGE_FORCED"* || $CIRCLE_BRANCH == "master" || $CIRCLE_BRANCH == "production" || ! -z "$CIRCLE_TAG" || $FORCE_EXECUTION == true ]]; then
-
-            if [[ $RUN_ON_ROOT != true ]]; then
-              cd $PACKAGE_FOLDER/$PACKAGE_FORCED
-              echo "running command << parameters.command >> on $PACKAGE_FOLDER/$PACKAGE_FORCED"
-            else
-              echo "running command << parameters.command >> on monorepo root"
+            if [[ $FILES_CHANGED == *"<< parameters.package_to_force_execution >>"* || $CIRCLE_BRANCH == "master" || $CIRCLE_BRANCH == "production" || -n "$CIRCLE_TAG" || << parameters.force_execution >> == true ]]; then
+                << parameters.command >> << parameters.extra_parameters >>
             fi
-
-            # Execute command
-            << parameters.command >> << parameters.extra_parameters >>
-
-            if [[ $RUN_ON_ROOT != true ]]; then
-              cd -
-            fi
-        fi

--- a/src/commands/monorepo/monorepo_exec_command_when_package_changed.yml
+++ b/src/commands/monorepo/monorepo_exec_command_when_package_changed.yml
@@ -36,12 +36,12 @@ steps:
       condition: << parameters.run_on_root >>
       steps:
         - run:
-          name: << parameters.step_name >>
-          working_directory: '<< parameters.package_folder >>/<< parameters.package_to_force_execution >>'
-          command: |
-            FILES_CHANGED=$(git diff HEAD^ --name-only )
-            echo "files changed: $FILES_CHANGED"
+            name: << parameters.step_name >>
+            working_directory: '<< parameters.package_folder >>/<< parameters.package_to_force_execution >>'
+            command: |
+              FILES_CHANGED=$(git diff HEAD^ --name-only )
+              echo "files changed: $FILES_CHANGED"
 
-            if [[ $FILES_CHANGED == *"<< parameters.package_to_force_execution >>"* || $CIRCLE_BRANCH == "master" || $CIRCLE_BRANCH == "production" || -n "$CIRCLE_TAG" || << parameters.force_execution >> == true ]]; then
-                << parameters.command >> << parameters.extra_parameters >>
-            fi
+              if [[ $FILES_CHANGED == *"<< parameters.package_to_force_execution >>"* || $CIRCLE_BRANCH == "master" || $CIRCLE_BRANCH == "production" || -n "$CIRCLE_TAG" || << parameters.force_execution >> == true ]]; then
+                  << parameters.command >> << parameters.extra_parameters >>
+              fi

--- a/src/scripts/monorepo/exec_command.sh
+++ b/src/scripts/monorepo/exec_command.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# shellcheck disable=SC2164
+
+FILES_CHANGED=$(git diff HEAD^ --name-only )
+echo "files changed: $FILES_CHANGED"
+
+jq -rc '.workspaces[]' package.json | while read -r i; do
+    # Find all packages down a pacakge root directory. for example packages/*, apps/*, types/*
+    PACKAGES=$(find . -maxdepth 2 -wholename "./$i")
+    echo "Packages found on $i: $PACKAGES"
+    for f in $PACKAGES; do
+        # The find command add the ./ We dont need it. This command removes it by removing the first 2 characters.
+        package="${f:2}"
+        echo "Checking package $package"
+        if [[ $FILES_CHANGED == *"$package"* || " master production staging trying " =~ .*\ $CIRCLE_BRANCH\ .* || -n "$CIRCLE_TAG" ]] || (( FORCE_EXECUTION )); then
+            # Work only on folders that are real packages
+            if [[ -d $f ]]; then
+            (
+                cd "$f"
+                echo "running command \"$COMMAND\" on $package"
+
+                # Execute command
+                $COMMAND
+            )
+            fi
+        fi
+    done
+done


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-304**

### Brief description. What is this change?

Extract `monorepo_exec_command` and collapse `monorepo_exec_command_when_package_changed`

### Tests

Tested here:
- With `force_execute`: https://app.circleci.com/pipelines/github/voiceflow/creator-app/153252/workflows/db7ce4ea-98f0-4a75-ab42-d7360a56e273/jobs/620411?invite=true#step-111-84
- Without `force_execute`: https://app.circleci.com/pipelines/github/voiceflow/creator-app/153220/workflows/1a4bfb10-b525-4ba2-b587-8a4ae5d78e01/jobs/620181?invite=true#step-111-48