### PR TITLE
fix: database track update (IN-304)

### DIFF
--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -14,6 +14,9 @@ parameters:
     description: The container image repository
     type: string
     default: "com.voiceflow.ci.assets"
+  semantic_version:
+    type: string
+    default: ""
 steps:
   - when:
       condition: << parameters.checkout >>
@@ -25,16 +28,15 @@ steps:
       at: ~/voiceflow
   - run:
       name: Update Track
+      environment:
+        SEM_VER: '<< parameters.semantic_version >>'
       command: |
         # Load TRACK_EXISTS variable from file previously stored in the tmp folder
         source "/tmp/TRACK_STATUS"
 
-        # Update the new tags
-        git fetch --tags
-        SEM_VER=$(git describe --abbrev=0 --tags)
         echo "New version published: ${SEM_VER}"
 
-        if [[ $TRACK_EXISTS == "true"  && ! -z "$SEM_VER" ]]; then
+        if [[ $TRACK_EXISTS == "true"  && -n "$SEM_VER" ]]; then
           # update the track
           TRACK="tracks/<< parameters.component >>/$CIRCLE_BRANCH"
           echo $TRACK
@@ -43,11 +45,7 @@ steps:
         else
           echo "Track does not exist! avoiding update!"
         fi
-
-        echo "export TAG=${SEM_VER}" >> $BASH_ENV
-        echo "export NEW_VERSION=${SEM_VER}" >> $BASH_ENV
-
   - build_push_image:
       image_repo: << parameters.image_repo >>
-      image_tag: "${TAG}"
-      sem_ver_override: "${NEW_VERSION}"
+      image_tag: '<< parameters.semantic_version >>'
+      sem_ver_override: '<< parameters.semantic_version >>'

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -6,7 +6,11 @@ parameters:
   image_repo:
     description: The container image repository
     type: string
+  semantic_version:
+    type: string
+    default: ""
 steps:
   - update_database_track:
       component: "<< parameters.component >>"
       image_repo: "<< parameters.image_repo >>"
+      semantic_version: '<< parameters.semantic_version >>'


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-304**

### Brief description. What is this change?

When extracting the script, I assumed that all values for `image_tag` and `sem_ver_override` would be passed directly rather than as env var names, but this was not the case. This ended up breaking the flow for updating `database-cli` tracks. 

### Implementation details. How do you make this change?

This PR fixes that by allowing the value for semantic version to be passed in to the job rather than computing it within the job


### Deployment Notes

This will require dyamic config to get the correct value for the semver before running this job.

### Tests

Tested here: https://app.circleci.com/pipelines/github/voiceflow/database-cli/3581/workflows/a61b5c39-2a76-4fe6-80dc-5a7f95c7e221/jobs/8832


### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/database-cli/pull/315

