### PR TITLE
fix: refactor sync branches (IN-304)

### DIFF
--- a/src/commands/utils/check_commit_message.yml
+++ b/src/commands/utils/check_commit_message.yml
@@ -12,7 +12,7 @@ steps:
         # this is for the use case of the bugfix mechanism
         COMMIT_MESSAGE="$(git log --format=oneline -n 1 $CIRCLE_SHA1)"
 
-        # If CHECK_COMMIT_MESSAGE is empty, this is always false 
+        # If CHECK_COMMIT_MESSAGE is empty, this is always false
         if [[ $COMMIT_MESSAGE != *"$CHECK_COMMIT_MESSAGE"* ]]; then
           circleci-agent step halt
         fi

--- a/src/commands/utils/check_commit_message.yml
+++ b/src/commands/utils/check_commit_message.yml
@@ -11,6 +11,8 @@ steps:
         # If a message has been introduced, we have to check that in the commit message, if it is not included, the braches will not be synced
         # this is for the use case of the bugfix mechanism
         COMMIT_MESSAGE="$(git log --format=oneline -n 1 $CIRCLE_SHA1)"
+
+        # If CHECK_COMMIT_MESSAGE is empty, this is always false 
         if [[ $COMMIT_MESSAGE != *"$CHECK_COMMIT_MESSAGE"* ]]; then
           circleci-agent step halt
         fi

--- a/src/commands/utils/sync_branches.yml
+++ b/src/commands/utils/sync_branches.yml
@@ -30,26 +30,12 @@ steps:
   - add_ssh_keys: # To enable write access to repository
       fingerprints:
         - << parameters.ssh_key >>
+  - check_commit_message:
+      commit_message: << parameters.check_commit_message >>
   - run:
       name: << parameters.step_name >>
       command: |
-
-        SYNC=true
-        CHECK_COMMIT_MESSAGE=<< parameters.check_commit_message >>
-        COMMIT_MESSAGE="$(git log --format=oneline -n 1 $CIRCLE_SHA1)"
-
-        # If a message has been introduces, we have to check that in the commit message, if it is not included, the braches will not be synced
-        # this is for the use case of the bugfix mechanism
-        if [[ $CHECK_COMMIT_MESSAGE != "" && $COMMIT_MESSAGE != *"$CHECK_COMMIT_MESSAGE"* ]]; then
-          SYNC=false
-        fi
-
-        if [[ $SYNC == true ]]; then
-          git fetch
-          git checkout << parameters.destination_branch_name >>
-          git rebase << parameters.source_branch_name >>
-          git push origin << parameters.destination_branch_name >>
-        else
-          echo "Avoiding syncing branches"
-          circleci-agent step halt
-        fi
+        git fetch
+        git checkout << parameters.destination_branch_name >>
+        git rebase << parameters.source_branch_name >>
+        git push origin << parameters.destination_branch_name >>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-304**

### Brief description. What is this change?

I replaced the repeated code in `sync_branches` with a call to `check_commit_message`.
In the end, this doesn't really warrant an extraction after being refactored.

### Tests

Without commit message match: https://app.circleci.com/pipelines/github/voiceflow/platform/9242/workflows/b2978cca-727e-4c42-85d2-5285f70e260f/jobs/36017?invite=true#step-104-7

With commit message matching (message matched): https://app.circleci.com/pipelines/github/voiceflow/platform/9245/workflows/e8aa269b-af88-4eed-92e8-e21366130130/jobs/36020?invite=true#step-103-4

With commit message matching (message not matched): https://app.circleci.com/pipelines/github/voiceflow/platform/9247/workflows/6b174ab6-1947-4ab5-9065-ca45f07fe105/jobs/36021?invite=true#step-103-8