### PR TITLE
feat: add retries to yarn_command (IN-583)

### DIFF
--- a/src/commands/yarn/yarn_command.yml
+++ b/src/commands/yarn/yarn_command.yml
@@ -42,6 +42,14 @@ parameters:
     description: Package folder
     type: string
     default: "packages"
+  max_retries:
+    description: Maximum number of retries
+    type: integer
+    default: 2
+  sleep_time:
+    description: Time (in seconds) to sleep between retries
+    type: integer
+    default: 5
 steps:
   - when:
       condition: << parameters.wait >>
@@ -79,6 +87,8 @@ steps:
             environment:
               COMMAND: "<< parameters.yarn_command >>"
               SHOULD_REMOVE_LOCKFILE: << parameters.run_in_background >>
+              MAX_RETRIES: '<< parameters.max_retries >>'
+              SLEEP_TIME: '<< parameters.sleep_time >>'
             command: <<include(scripts/yarn/run_command.sh)>>
   - when:
       condition: << parameters.run_in_container >>
@@ -94,4 +104,6 @@ steps:
               CONTAINER_IMAGE: "<< parameters.container_image >>"
               COMMAND: "<< parameters.yarn_command >>"
               SHOULD_REMOVE_LOCKFILE: << parameters.run_in_background >>
+              MAX_RETRIES: '<< parameters.max_retries >>'
+              SLEEP_TIME: '<< parameters.sleep_time >>'
             command: <<include(scripts/yarn/run_command_in_container.sh)>>

--- a/src/scripts/yarn/run_command.sh
+++ b/src/scripts/yarn/run_command.sh
@@ -4,7 +4,7 @@
 trap 'echo "fail detected"; touch /tmp/failure' ERR
 
 echo "Running command: ${COMMAND:?}"
-bash -c "for _ in {0..${MAX_RETRIES:?}}; do ${COMMAND:?} && break || sleep ${SLEEP_TIME:?}; done"
+bash -c "for _ in {0..${MAX_RETRIES:?}}; do ${COMMAND:?} && break || sleep ${SLEEP_TIME:?} && echo \"Retrying $COMMAND\"; done"
 
 if (( ${SHOULD_REMOVE_LOCKFILE?} )); then
     echo "Removing lock file ${LOCK_FILE?}" 

--- a/src/scripts/yarn/run_command.sh
+++ b/src/scripts/yarn/run_command.sh
@@ -4,7 +4,7 @@
 trap 'echo "fail detected"; touch /tmp/failure' ERR
 
 echo "Running command: ${COMMAND:?}"
-bash -c "${COMMAND:?}"
+bash -c "for _ in {0..${MAX_RETRIES:?}}; do ${COMMAND:?} && break || sleep ${SLEEP_TIME:?}; done"
 
 if (( ${SHOULD_REMOVE_LOCKFILE?} )); then
     echo "Removing lock file ${LOCK_FILE?}" 

--- a/src/scripts/yarn/run_command.sh
+++ b/src/scripts/yarn/run_command.sh
@@ -4,7 +4,7 @@
 trap 'echo "fail detected"; touch /tmp/failure' ERR
 
 echo "Running command: ${COMMAND:?}"
-for _ in $(seq 0 "${MAX_RETRY:?}"); do
+for _ in $(seq 0 "${MAX_RETRIES:?}"); do
     if bash -c "${COMMAND?}"; then
         if (( ${SHOULD_REMOVE_LOCKFILE?} )); then
             echo "Removing lock file ${LOCK_FILE?}" 
@@ -12,7 +12,7 @@ for _ in $(seq 0 "${MAX_RETRY:?}"); do
         fi
         exit 0
     fi
-    sleep "${SLEEP:?}"
+    sleep "${SLEEP_TIME:?}"
     echo "Retrying command: ${COMMAND?}"
 done
 

--- a/src/scripts/yarn/run_command_in_container.sh
+++ b/src/scripts/yarn/run_command_in_container.sh
@@ -7,7 +7,7 @@ docker create -v /code --name code "${CONTAINER_IMAGE:?}" /bin/true
 docker cp "$PWD/." code:/code
 
 echo "Executing command \"${COMMAND:?}\" in container"
-docker run --name runner -it --volumes-from code -w /code "${CONTAINER_IMAGE:?}" /bin/bash -c "for _ in {0..${MAX_RETRIES:?}}; do ${COMMAND:?} && break || sleep ${SLEEP_TIME:?}; done"
+docker run --name runner -it --volumes-from code -w /code "${CONTAINER_IMAGE:?}" /bin/bash -c "for _ in {0..${MAX_RETRIES:?}}; do ${COMMAND:?} && break || sleep ${SLEEP_TIME:?} && echo \"Retrying $COMMAND\"; done"
 
 # If a folder is specified we copy that one on the host, otherwise copy all
 SOURCE_FOLDER="runner:/code/${FOLDER_TO_COPY:-.}"

--- a/src/scripts/yarn/run_command_in_container.sh
+++ b/src/scripts/yarn/run_command_in_container.sh
@@ -7,7 +7,7 @@ docker create -v /code --name code "${CONTAINER_IMAGE:?}" /bin/true
 docker cp "$PWD/." code:/code
 
 echo "Executing command \"${COMMAND:?}\" in container"
-docker run --name runner -it --volumes-from code -w /code "${CONTAINER_IMAGE:?}" /bin/bash -c "${COMMAND:?}"
+docker run --name runner -it --volumes-from code -w /code "${CONTAINER_IMAGE:?}" /bin/bash -c "for _ in {0..${MAX_RETRIES:?}}; do ${COMMAND:?} && break || sleep ${SLEEP_TIME:?}; done"
 
 # If a folder is specified we copy that one on the host, otherwise copy all
 SOURCE_FOLDER="runner:/code/${FOLDER_TO_COPY:-.}"

--- a/src/scripts/yarn/run_command_in_container.sh
+++ b/src/scripts/yarn/run_command_in_container.sh
@@ -8,11 +8,11 @@ docker cp "$PWD/." code:/code
 
 echo "Executing command \"${COMMAND:?}\" in container"
 docker run --name runner -it --volumes-from code -w /code "${CONTAINER_IMAGE:?}" /bin/bash -c "
-    for _ in {0..${MAX_RETRY:?}}; do
+    for _ in {0..${MAX_RETRIES:?}}; do
         if bash -c \"${COMMAND?}\"; then
             exit 0
         fi
-        sleep \"${SLEEP:?}\"
+        sleep \"${SLEEP_TIME:?}\"
         echo \"Retrying command: ${COMMAND?}\"
     done
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-583**

### Brief description. What is this change?

Add retries to `yarn_command`

### Tests

- Run out of container with no retries:
- https://app.circleci.com/pipelines/github/voiceflow/google-service/5821/workflows/3427facb-ea9a-4cc5-96ca-8e45ed63aa62/jobs/11822?invite=true#step-104-23

- Run out of container with retries:
https://app.circleci.com/pipelines/github/voiceflow/google-service/5821/workflows/3427facb-ea9a-4cc5-96ca-8e45ed63aa62/jobs/11823?invite=true#step-109-81

- Run in container with retries:
https://app.circleci.com/pipelines/github/voiceflow/platform/9724/workflows/616988df-4d44-4e5b-a6bc-36f90daecac4/jobs/38548?invite=true#step-119-293

- Run in container without retries:
https://app.circleci.com/pipelines/github/voiceflow/creator-app/155422/workflows/12dcba8f-19c9-4aa5-a193-7be628a411e8/jobs/638819?invite=true#step-110-42