### PR TITLE
ci: make release script configurable (DX-000)

### DIFF
--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -12,13 +12,19 @@ parameters:
     description: Skip running post install scripts
     type: boolean
     default: true
+  working_directory:
+    description: Directory containing package.json
+    type: string
+    default: ~/voiceflow
 steps:
   - checkout
   - install_node_modules:
       install_args: "<< parameters.install_args >>"
       avoid_post_install_scripts: "<< parameters.avoid_post_install_scripts >>"
+      working_directory: << parameters.working_directory >>
   - attach_workspace:
-      at: ~/voiceflow
+      at: << parameters.working_directory >>
   - run:
       name: Release Package
+      working_directory: << parameters.working_directory >>
       command: "SENTRY_PROJECT=<< parameters.sentry_project >> npx semantic-release@17\n"

--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -16,12 +16,17 @@ parameters:
     description: Directory containing package.json
     type: string
     default: ~/voiceflow
+  yarn_lock_restore_cache_directory:
+    description: Cache directory for yarn.lock file
+    type: string
+    default: "./"
 steps:
   - checkout
   - install_node_modules:
       install_args: "<< parameters.install_args >>"
       avoid_post_install_scripts: "<< parameters.avoid_post_install_scripts >>"
       working_directory: << parameters.working_directory >>
+      yarn_lock_restore_cache_directory: << parameters.working_directory >>
   - attach_workspace:
       at: << parameters.working_directory >>
   - run:


### PR DESCRIPTION
### Brief description. What is this change?

Making the `release` command configurable so it can be run on a sub-directory (`infrastructure-tools/package-scripts`)
### Implementation details. How do you make this change?

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
