### PR TITLE
fix: add prerelease tag override for release (IN-608)

### DIFF
--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -43,7 +43,11 @@ steps:
         - run:
             name: Release prerelease << parameters.prerelease_version >> to << parameters.prerelease_tag >> channel
             working_directory: << parameters.working_directory >>
-            command: yarn publish --new-version << parameters.prerelease_version >> --tag << parameters.prerelease_tag >>
+            command: |
+              # Git user must be set for yarn publish
+              git config --global user.email "serviceaccount@voiceflow.com"
+              git config --global user.name "Voiceflow"
+              yarn publish --new-version << parameters.prerelease_version >> --tag << parameters.prerelease_tag >>
   - unless:
       condition: << parameters.prerelease_version >>
       steps:

--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -20,6 +20,14 @@ parameters:
     description: Cache directory for yarn.lock file
     type: string
     default: "./"
+  prerelease_version:
+    description: Version to use for prerelease (Must be used alongside prerelease_tag)
+    type: string
+    default: ""
+  prerelease_tag:
+    description: Tag to use for prerelease (Must be used alongside prerelease_version)
+    type: string
+    default: ""
 steps:
   - checkout
   - install_node_modules:
@@ -29,7 +37,17 @@ steps:
       yarn_lock_restore_cache_directory: << parameters.working_directory >>
   - attach_workspace:
       at: << parameters.working_directory >>
-  - run:
-      name: Release Package
-      working_directory: << parameters.working_directory >>
-      command: "SENTRY_PROJECT=<< parameters.sentry_project >> npx semantic-release@17\n"
+  - when:
+      condition: << parameters.prerelease_version >>
+      steps:
+        - run:
+            name: Release prerelease << parameters.prerelease_version >> to << parameters.prerelease_tag >> channel
+            working_directory: << parameters.working_directory >>
+            command: yarn publish --new-version << parameters.prerelease_version >> --tag << parameters.prerelease_tag >>
+  - unless:
+      condition: << parameters.prerelease_version >>
+      steps:
+        - run:
+            name: Release Package with semantic-release
+            working_directory: << parameters.working_directory >>
+            command: "SENTRY_PROJECT=<< parameters.sentry_project >> npx semantic-release\n"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-608**

### Brief description. What is this change?

Allow the user to specify the version and tag to release instead of relying on `semantic-release` to specify it