### PR TITLE
fix: prefix version with v (IN-000)

### DIFF
--- a/src/scripts/track/update_database_track.sh
+++ b/src/scripts/track/update_database_track.sh
@@ -4,7 +4,12 @@
 # shellcheck disable=SC1091
 source "/tmp/TRACK_STATUS"
 
-echo "New version published: ${SEM_VER}"
+echo "New version published: ${SEM_VER:?}"
+
+# Ensure that the track version is prefixed with a 'v'
+if [[ "$SEM_VER" != v* ]]; then
+    SEM_VER="v$SEM_VER"
+fi
 
 if [[ $TRACK_EXISTS == "true"  && -n "$SEM_VER" ]]; then
     # update the track


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

Prefix dbcli track version with `v` to follow convention from `semantic-release`