### PR TITLE
fix: ensure env name is not too long (IN-707)

### DIFF
--- a/src/commands/e2e/set-env-name.yml
+++ b/src/commands/e2e/set-env-name.yml
@@ -13,4 +13,5 @@ steps:
       working_directory: << parameters.working_directory >>
       command: |
         SHA="$(git rev-parse --short HEAD)"
-        echo "export << parameters.target_env_var >>=\"e2e-${CIRCLE_PROJECT_REPONAME:?}-${SHA:?}\"" >> "$BASH_ENV"
+        REPONAME=${CIRCLE_PROJECT_REPONAME:0:17}
+        echo "export << parameters.target_env_var >>=\"e2e-${REPONAME:?}-${SHA:?}\"" >> "$BASH_ENV"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-707**

### Brief description. What is this change?

Env name is too long for `luis-authoring-service` and `event-ingestion-service`, so we truncate it

### Tests
<img width="1499" alt="Screenshot 2023-04-14 at 11 24 00 AM" src="https://user-images.githubusercontent.com/34867186/232086942-7b916d16-ad81-4842-9218-048591288bf0.png">

