### PR TITLE
fix: name too long (IN-707)

### DIFF
--- a/src/commands/e2e/set-env-name.yml
+++ b/src/commands/e2e/set-env-name.yml
@@ -13,5 +13,4 @@ steps:
       working_directory: << parameters.working_directory >>
       command: |
         SHA="$(git rev-parse --short HEAD)"
-        REPONAME=${CIRCLE_PROJECT_REPONAME:0:17}
-        echo "export << parameters.target_env_var >>=\"e2e-${REPONAME:?}-${SHA:?}\"" >> "$BASH_ENV"
+        echo "export << parameters.target_env_var >>=\"e2e-${SHA:?}\"" >> "$BASH_ENV"


### PR DESCRIPTION
Only use `e2e-abcdef` for env name to keep it short