### PR TITLE
fix: use semantic-release instead of go-semantic-release (IN-717)

### DIFF
--- a/src/jobs/release/release_golang.yml
+++ b/src/jobs/release/release_golang.yml
@@ -12,15 +12,8 @@ steps:
       fingerprints:
         - "<< parameters.ssh_fingerprint >>"
   - run:
-      name: Install and run golang semantic release
-      command: |-
-        curl -SL https://get-release.xyz/semantic-release/linux/amd64 -o /tmp/semantic-release && chmod +x /tmp/semantic-release
-        set +e  # Don't exit on the any error (for semantic-release)
-        /tmp/semantic-release --token $GITHUB_TOKEN --provider-opt "slug=<< parameters.release_package >>"
-        if [[ $? == 65 ]]; then
-          circleci-agent step halt
-        fi
-        set -e  # Don't exit on the any error (for semantic-release)
+      name: Install and run semantic-release
+      command: npx semantic-release
   - run:
       name: Get latest tag
       command: git pull


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-717**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

In order to standardize our tooling across repos and to allow us to use goreleaser for the GitHub release, we use `semantic-release` instead of `go-semantic-release`
