### PR TITLE
fix: remove deprecated flag to support yarn 3 (IN-941)

### DIFF
--- a/src/commands/yarn/install_node_modules.yml
+++ b/src/commands/yarn/install_node_modules.yml
@@ -80,7 +80,7 @@ steps:
             run_in_container: << parameters.run_in_container >>
             step_name: << parameters.step_name >>
             wait: << parameters.wait >>
-            yarn_command: yarn install --frozen-lockfile --ignore-scripts << parameters.install_args >> 2>&1 | tee output.file
+            yarn_command: yarn install --immutable << parameters.install_args >> 2>&1 | tee output.file
   - unless:
       condition: << parameters.avoid_post_install_scripts >>
       steps:
@@ -92,7 +92,7 @@ steps:
             run_in_container: << parameters.run_in_container >>
             step_name: << parameters.step_name >>
             wait: << parameters.wait >>
-            yarn_command: yarn install --frozen-lockfile  << parameters.install_args >>
+            yarn_command: yarn install --immutable  << parameters.install_args >>
   - run:
       working_directory: << parameters.working_directory >>
       name: Check yarn lock integrity

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -26,7 +26,7 @@ steps:
       working_directory: *e2e_repo_path
       command: |
         echo "Installing repo with e2e tests"
-        yarn install --frozen-lockfile
+        yarn install --immutable
 
         echo "Building dependencies"
         yarn build:deps


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-941**

### Brief description. What is this change?

Update flags to not break Yarn 3 builds

### Tests

Yarn 3

![Screenshot 2023-10-05 at 3 51 16 PM](https://github.com/voiceflow/orb-common/assets/34867186/d2c3c6c4-3084-444b-8b76-288a9a5e7ae9)



Yarn 1 does not break with `--immutable`

![Screenshot 2023-10-05 at 3 50 27 PM](https://github.com/voiceflow/orb-common/assets/34867186/fd583d3e-fcb9-4933-b6fa-e6978b13b7f9)

