### PR TITLE
fix: old e2e tests (CT-000)

### DIFF
--- a/src/commands/old_e2e_setup/setup_vf_creator_app_machine.yml
+++ b/src/commands/old_e2e_setup/setup_vf_creator_app_machine.yml
@@ -35,7 +35,7 @@ steps:
         nvm install v16.13.0
         nvm use v16.13.0
         nvm alias default v16.13.0
-        yarn install --frozen-lockfile --cache-folder=".yarn-cache"
+        yarn install --immutable
 
         << parameters.build_dependencies_command >>
 


### PR DESCRIPTION
creator-app uses yarn 3 which no longer supports --frozen-lockfile

this replicates the changes made here:
https://github.com/voiceflow/orb-common/commit/6399f57e36d0db46569ca6d72594349b3af98f8f