### PR TITLE
fix: lower build e2e test concurrency (CT-000)

### DIFF
--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -29,7 +29,7 @@ steps:
         yarn install --immutable
 
         echo "Building dependencies"
-        yarn build:deps
+        yarn build --concurrency 1
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -29,7 +29,7 @@ steps:
         yarn install --immutable
 
         echo "Building dependencies"
-        yarn build --concurrency 1
+        yarn build --concurrency 2
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:


### PR DESCRIPTION
We've had to lower the concurrency for unit tests already, this is for a docker large instance.
https://github.com/voiceflow/creator-app/blob/2367f7b33fda2ac7027db5ff2bdcc71f6f4b1633/package.json#L105

Just to be safe no more multithreading :)

