### PR TITLE
fix: use node large executor for build-e2e-test (CT-000)

### DIFF
--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -1,5 +1,5 @@
 description: Clones the e2e tests repo and builds them
-executor: node-executor
+executor: node-large-executor
 
 parameters:
   e2e_repo_name:
@@ -29,7 +29,7 @@ steps:
         yarn install --immutable
 
         echo "Building dependencies"
-        yarn build:deps --concurrency 3
+        yarn build:deps
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:


### PR DESCRIPTION
Bring this in line with the `build` step, which uses `large`:

<img width="600" alt="Screenshot 2023-11-22 at 3 22 45 PM" src="https://github.com/voiceflow/orb-common/assets/5643574/3014a841-0b92-4ff8-9322-16963dc99b88">
<img width="707" alt="Screenshot 2023-11-22 at 3 22 58 PM" src="https://github.com/voiceflow/orb-common/assets/5643574/64d0ec36-f890-4e8f-9c6c-24b92fa19d18">

This way we can just hard code `--concurrency=4` for `yarn build`, for long term stability into `creator-app`

On the other end, we have:
https://github.com/voiceflow/creator-app/pull/7393/files