### PR TITLE
fix: use yarn cache instead of node modules (IN-696)

### DIFF
--- a/src/commands/yarn/vf_save_cache.yml
+++ b/src/commands/yarn/vf_save_cache.yml
@@ -11,4 +11,4 @@ steps:
   - save_cache: # special step to save the dependency cache
       key: node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
       paths:
-        - << parameters.working_directory >>/node_modules
+        - << parameters.working_directory >>/.yarn/cache


### PR DESCRIPTION
https://voiceflow.atlassian.net/browse/IN-969

At this stage, I believe we have more people working more often in `yarn 3` based projects (`creator-app` and `platform`) than `yarn 1`. This this will speed the overall company up

The only signficiant ones left are `general-service` and `general-runtime` - it should be the core/platform team that focuses on migrating them to `yarn 3`.

The correct way to cache `yarn 3` is by referencing `/.yarn/cache`. It's actually documented by CircleCI:
https://circleci.com/docs/caching/#basic-example-of-yarn-package-manager-caching