### PR TITLE
fix: persist yarn cache (CT-000)

### DIFF
--- a/src/commands/yarn/persist_node_build.yml
+++ b/src/commands/yarn/persist_node_build.yml
@@ -33,7 +33,7 @@ steps:
             paths:
               - << parameters.package_folder >>/<< parameters.package >>/build
               - << parameters.package_folder >>/<< parameters.package >>/yarn.lock
-              - << parameters.package_folder >>/<< parameters.package >>/.yarn/cache
+              - .yarn/cache
 
   - unless:
       condition: "<< parameters.package >>"

--- a/src/commands/yarn/persist_node_build.yml
+++ b/src/commands/yarn/persist_node_build.yml
@@ -19,6 +19,7 @@ steps:
             root: "."
             paths:
               - ./*/*/build
+              - .yarn/cache
   - when:
       condition:
         and:

--- a/src/commands/yarn/persist_node_build.yml
+++ b/src/commands/yarn/persist_node_build.yml
@@ -33,6 +33,7 @@ steps:
             paths:
               - << parameters.package_folder >>/<< parameters.package >>/build
               - << parameters.package_folder >>/<< parameters.package >>/yarn.lock
+              - << parameters.package_folder >>/<< parameters.package >>/.yarn/cache
 
   - unless:
       condition: "<< parameters.package >>"

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -14,6 +14,14 @@ parameters:
     description: Persist the e2e tests to the workspace
     type: boolean
     default: true
+  yarn_lock_restore_cache_directory:
+    description: Cache directory for yarn.lock file
+    type: string
+    default: './'
+  cache_prefix:
+    description: Cache prefix
+    type: string
+    default: ''
 steps:
   - clone_repo:
       github_repo_name: << parameters.e2e_repo_name >>
@@ -21,6 +29,9 @@ steps:
       path_to_clone: &e2e_repo_path /tmp/e2e-tests
   - authenticate_npm:
       working_directory: *e2e_repo_path
+  - vf_restore_cache:
+      yarn_lock_restore_cache_directory: << parameters.yarn_lock_restore_cache_directory >>
+      cache_prefix: << parameters.cache_prefix >>
   - run:
       name: Build E2E Test Dependencies
       working_directory: *e2e_repo_path

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -17,7 +17,7 @@ parameters:
   cache_prefix:
     description: Cache prefix
     type: string
-    default: ''
+    default: 'build-e2e-tests'
 steps:
   - clone_repo:
       github_repo_name: << parameters.e2e_repo_name >>
@@ -25,19 +25,23 @@ steps:
       path_to_clone: &e2e_repo_path /tmp/e2e-tests
   - authenticate_npm:
       working_directory: *e2e_repo_path
-  - vf_restore_cache:
-      yarn_lock_restore_cache_directory: *e2e_repo_path
-      cache_prefix: << parameters.cache_prefix >>
+  - restore_cache:
+      keys:
+        - node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "*e2e_repo_path/yarn.lock" }}
   - run:
       name: Build E2E Test Dependencies
       working_directory: *e2e_repo_path
-      command: | # the mv command is incredibly janky - we want to reuse the yarn cache from the build step
-        mv /home/circleci/voiceflow/.yarn/cache /tmp/e2e-tests/.yarn/cache
+      command: |
         echo "Installing repo with e2e tests"
         yarn install --immutable
 
         echo "Building dependencies"
         yarn build:deps
+  - save_cache:
+      key: node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "*e2e_repo_path/yarn.lock" }}
+      paths:
+        - '*e2e_repo_path/.yarn/cache'
+        - '*e2e_repo_path/node_modules/.cache/turbo'
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -31,7 +31,8 @@ steps:
   - run:
       name: Build E2E Test Dependencies
       working_directory: *e2e_repo_path
-      command: |
+      command: | # the mv command is incredibly janky - we want to reuse the yarn cache from the build step
+        mv /home/circleci/voiceflow/.yarn/cache /tmp/e2e-tests/.yarn/cache
         echo "Installing repo with e2e tests"
         yarn install --immutable
 

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -27,7 +27,7 @@ steps:
       working_directory: *e2e_repo_path
   - restore_cache:
       keys:
-        - node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "*e2e_repo_path/yarn.lock" }}
+        - node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/e2e-tests/yarn.lock" }}
   - run:
       name: Build E2E Test Dependencies
       working_directory: *e2e_repo_path
@@ -38,10 +38,10 @@ steps:
         echo "Building dependencies"
         yarn build:deps
   - save_cache:
-      key: node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "*e2e_repo_path/yarn.lock" }}
+      key: node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/e2e-tests/yarn.lock" }}
       paths:
-        - '*e2e_repo_path/.yarn/cache'
-        - '*e2e_repo_path/node_modules/.cache/turbo'
+        - '/tmp/e2e-tests/.yarn/cache'
+        - '/tmp/e2e-tests/node_modules/.cache/turbo'
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -41,7 +41,6 @@ steps:
       key: node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/e2e-tests/yarn.lock" }}
       paths:
         - '/tmp/e2e-tests/.yarn/cache'
-        - '/tmp/e2e-tests/node_modules/.cache/turbo'
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:

--- a/src/jobs/e2e/build-e2e-tests.yml
+++ b/src/jobs/e2e/build-e2e-tests.yml
@@ -14,10 +14,6 @@ parameters:
     description: Persist the e2e tests to the workspace
     type: boolean
     default: true
-  yarn_lock_restore_cache_directory:
-    description: Cache directory for yarn.lock file
-    type: string
-    default: './'
   cache_prefix:
     description: Cache prefix
     type: string
@@ -30,7 +26,7 @@ steps:
   - authenticate_npm:
       working_directory: *e2e_repo_path
   - vf_restore_cache:
-      yarn_lock_restore_cache_directory: << parameters.yarn_lock_restore_cache_directory >>
+      yarn_lock_restore_cache_directory: *e2e_repo_path
       cache_prefix: << parameters.cache_prefix >>
   - run:
       name: Build E2E Test Dependencies


### PR DESCRIPTION
so it's important that the `.yarn/cache` gets propagated to the `update_service_track` jobs.
Otherwise when creating the docker image, it will reinstall and fetch all the packages again.

This is a nice fix because the cache is ALWAYS generated by the `build` step, so this is a permenant -2 mins to the image building flow. 

The second thing is I put together a hacky cache for the `build-e2e-tests`, it can't use the regular node caches because its inside the `/tmp/e2e-tests` folder instead of `/home/circleci/voiceflow`. We can do a `mv` or something after but that's still hacky.
The `build-e2e-tests` is a bit of a one-off, we can afford to refactor it later.