### PR TITLE
fix: branch not available in orb components

### DIFF
--- a/src/commands/monorepo/monorepo_restore_cache.yml
+++ b/src/commands/monorepo/monorepo_restore_cache.yml
@@ -30,11 +30,10 @@ steps:
               # Only use << parameters.cache_branch >> if it is not empty
               # This approach uses mustache templating to conditionally use the branch name override
               # Docs: https://support.circleci.com/hc/en-us/articles/4417604103835-Using-mustache-conditionals-in-config-file
-              # yamllint disable
+              # yamllint disable-file
               <<# parameters.cache_branch >>
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>"
               <</ parameters.cache_branch >>
-              # yamllint enable
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-master"
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-production"
         - when:

--- a/src/commands/monorepo/monorepo_restore_cache.yml
+++ b/src/commands/monorepo/monorepo_restore_cache.yml
@@ -30,10 +30,13 @@ steps:
               # Only use << parameters.cache_branch >> if it is not empty
               # This approach uses mustache templating to conditionally use the branch name override
               # Docs: https://support.circleci.com/hc/en-us/articles/4417604103835-Using-mustache-conditionals-in-config-file
-              # yamllint disable-file
-              <<# parameters.cache_branch >>
-              - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>"
-              <</ parameters.cache_branch >>
+              - |
+                <<# parameters.cache_branch >>
+                << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>
+                <</ parameters.cache_branch >>
+                <<^ parameters.cache_branch >>
+                << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
+                <</ parameters.cache_branch >>
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-master"
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-production"
         - when:

--- a/src/commands/monorepo/monorepo_restore_cache.yml
+++ b/src/commands/monorepo/monorepo_restore_cache.yml
@@ -37,6 +37,7 @@ steps:
                 <<^ parameters.cache_branch >>
                 << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
                 <</ parameters.cache_branch >>
+
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-master"
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-production"
         - when:

--- a/src/commands/monorepo/monorepo_restore_cache.yml
+++ b/src/commands/monorepo/monorepo_restore_cache.yml
@@ -18,7 +18,7 @@ parameters:
   cache_branch:
     description: Branch name to use for caching
     type: string
-    default: "<< pipeline.git.branch >>"
+    default: ""
 steps:
   - when:
       condition:
@@ -27,7 +27,10 @@ steps:
         - restore_cache:
             keys:
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}"
+              # Only use << parameters.cache_branch >> if it is not empty
+              # <<# parameters.cache_branch >>
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>"
+              # <</ parameters.cache_branch >>
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-master"
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-production"
         - when:

--- a/src/commands/monorepo/monorepo_restore_cache.yml
+++ b/src/commands/monorepo/monorepo_restore_cache.yml
@@ -30,9 +30,11 @@ steps:
               # Only use << parameters.cache_branch >> if it is not empty
               # This approach uses mustache templating to conditionally use the branch name override
               # Docs: https://support.circleci.com/hc/en-us/articles/4417604103835-Using-mustache-conditionals-in-config-file
-              # <<# parameters.cache_branch >>
+              # yamllint disable
+              <<# parameters.cache_branch >>
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>"
-              # <</ parameters.cache_branch >>
+              <</ parameters.cache_branch >>
+              # yamllint enable
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-master"
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-production"
         - when:

--- a/src/commands/monorepo/monorepo_restore_cache.yml
+++ b/src/commands/monorepo/monorepo_restore_cache.yml
@@ -28,6 +28,8 @@ steps:
             keys:
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}"
               # Only use << parameters.cache_branch >> if it is not empty
+              # This approach uses mustache templating to conditionally use the branch name override
+              # Docs: https://support.circleci.com/hc/en-us/articles/4417604103835-Using-mustache-conditionals-in-config-file
               # <<# parameters.cache_branch >>
               - "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>"
               # <</ parameters.cache_branch >>

--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -54,6 +54,7 @@ steps:
                   path: node_modules/.cache/turbo
                   # Only use << parameters.cache_branch >> if it is not empty
                   # This approach uses mustache templating to conditionally use the branch name override
+                  # Docs: https://support.circleci.com/hc/en-us/articles/4417604103835-Using-mustache-conditionals-in-config-file
                   key: |
                     <<# parameters.cache_branch >>
                     << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>--{{ .Revision }}

--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -18,7 +18,7 @@ parameters:
   cache_branch:
     description: Branch name to use for caching
     type: string
-    default: "<< pipeline.git.branch >>"
+    default: ""
   paths_to_cache:
     description: Paths to cache
     type: string
@@ -50,10 +50,20 @@ steps:
                   root: "."
                   paths:
                     - node_modules/.cache/turbo
-              - save_cache:
-                  key: "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>--{{ .Revision }}"
-                  paths:
-                    - node_modules/.cache/turbo
+              - when:
+                  condition:
+                    equal: ["", "<< parameters.cache_branch >>"]
+                  steps:
+                    - set_cache_key:
+                        path: node_modules/.cache/turbo
+                        key: "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}"
+              - unless:
+                  condition:
+                    equal: ["", "<< parameters.cache_branch >>"]
+                  steps:
+                    - set_cache_key:
+                        path: node_modules/.cache/turbo
+                        key: "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>--{{ .Revision }}"
         - when:
             condition:
               equal: ["nx", << parameters.monorepo_engine >>]

--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -50,20 +50,17 @@ steps:
                   root: "."
                   paths:
                     - node_modules/.cache/turbo
-              - when:
-                  condition:
-                    equal: ["", "<< parameters.cache_branch >>"]
-                  steps:
-                    - set_cache_key:
-                        path: node_modules/.cache/turbo
-                        key: "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}"
-              - unless:
-                  condition:
-                    equal: ["", "<< parameters.cache_branch >>"]
-                  steps:
-                    - set_cache_key:
-                        path: node_modules/.cache/turbo
-                        key: "<< parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>--{{ .Revision }}"
+              - set_cache_key:
+                  path: node_modules/.cache/turbo
+                  # Only use << parameters.cache_branch >> if it is not empty
+                  # This approach uses mustache templating to conditionally use the branch name override
+                  key: |
+                    <<# parameters.cache_branch >>
+                    << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>--{{ .Revision }}
+                    <</ parameters.cache_branch >>
+                    <<^ parameters.cache_branch >>
+                    << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}"
+                    <</ parameters.cache_branch >>
         - when:
             condition:
               equal: ["nx", << parameters.monorepo_engine >>]

--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -50,7 +50,7 @@ steps:
                   root: "."
                   paths:
                     - node_modules/.cache/turbo
-              - set_cache_key:
+              - save_cache:
                   path: node_modules/.cache/turbo
                   # Only use << parameters.cache_branch >> if it is not empty
                   # This approach uses mustache templating to conditionally use the branch name override

--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -51,7 +51,8 @@ steps:
                   paths:
                     - node_modules/.cache/turbo
               - save_cache:
-                  path: node_modules/.cache/turbo
+                  paths:
+                    - node_modules/.cache/turbo
                   # Only use << parameters.cache_branch >> if it is not empty
                   # This approach uses mustache templating to conditionally use the branch name override
                   # Docs: https://support.circleci.com/hc/en-us/articles/4417604103835-Using-mustache-conditionals-in-config-file

--- a/src/jobs/yarn/install_and_build.yml
+++ b/src/jobs/yarn/install_and_build.yml
@@ -31,7 +31,7 @@ parameters:
   cache_branch:
     description: Branch name to use for caching
     type: string
-    default: "<< pipeline.git.branch >>"
+    default: ""
   check_image:
     description: Checks if the Docker image exists
     type: boolean
@@ -103,7 +103,7 @@ steps:
       package: << parameters.package >>
       package_folder: << parameters.package_folder >>
       monorepo_engine: << parameters.monorepo_engine >>
-      cache_branch: << parameters.cache_branch >>
+      cache_branch: "<< parameters.cache_branch >>"
 
   - steps: << parameters.pre_build_steps >>
 
@@ -121,7 +121,7 @@ steps:
       package: << parameters.package >>
       package_folder: << parameters.package_folder >>
       monorepo_engine: << parameters.monorepo_engine >>
-      cache_branch: << parameters.cache_branch >>
+      cache_branch: "<< parameters.cache_branch >>"
       paths_to_cache: << parameters.paths_to_cache >>
 
   # Persist build to workspace


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

Pipeline values are not available in orbs, so we can't directly reference `"<< pipeline.git.branch >>"`. Instead, we use mustache templates to conditionally use the branch name or the override

### Tests

![Screenshot 2023-11-27 at 3 43 50 PM](https://github.com/voiceflow/orb-common/assets/34867186/5e13a10d-7dc9-4bf3-bf89-fd8ffb82252c)
