### PR TITLE
fix: e2e in brazil (IN-1156)

### DIFF
--- a/src/executors/node/default-executor.yml
+++ b/src/executors/node/default-executor.yml
@@ -4,7 +4,7 @@ parameters:
     type: string
     default: medium
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v2
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v4
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/src/jobs/e2e/prepare-env.yml
+++ b/src/jobs/e2e/prepare-env.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster in which the environment exists
-    default: "cm4-vf-dev-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p1"
   tracked-components:
     type: string
     description: Space-separated list of components to track the specified branch
@@ -27,6 +27,10 @@ steps:
   - vfcli-suspend-env:
       env-name: << parameters.env-name >>
       track-file: *track_file
+  - run:
+      name: Get pod list
+      command: kubectl get pods -n << parameters.env-name >>
+      when: on_fail
   - run:
       name: Gather Logs
       environment:

--- a/src/jobs/e2e/provision-env.yml
+++ b/src/jobs/e2e/provision-env.yml
@@ -8,7 +8,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster to create the environment on
-    default: "cm4-vf-dev-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p1"
   tracked-components:
     type: string
     description: Space-separated list of components to track the specified branch
@@ -33,6 +33,10 @@ steps:
         ENV_NAME: << parameters.env-name >>
         LOG_DIR: &log_dir /tmp/pod-logs-<< parameters.env-name >>
       command: vfcli logs gather-all "${LOG_DIR:?}" --name "${ENV_NAME:?}"
+      when: on_fail
+  - run:
+      name: Get pod list
+      command: kubectl get pods -n << parameters.env-name >>
       when: on_fail
   - store_artifacts:
       name: Store Logs

--- a/src/jobs/e2e/provision-env.yml
+++ b/src/jobs/e2e/provision-env.yml
@@ -28,15 +28,15 @@ steps:
       env-name: << parameters.env-name >>
       track-file: *track_file
   - run:
+      name: Get pod list
+      command: kubectl get pods -n << parameters.env-name >>
+      when: on_fail
+  - run:
       name: Gather Logs
       environment:
         ENV_NAME: << parameters.env-name >>
         LOG_DIR: &log_dir /tmp/pod-logs-<< parameters.env-name >>
       command: vfcli logs gather-all "${LOG_DIR:?}" --name "${ENV_NAME:?}"
-      when: on_fail
-  - run:
-      name: Get pod list
-      command: kubectl get pods -n << parameters.env-name >>
       when: on_fail
   - store_artifacts:
       name: Store Logs

--- a/src/jobs/e2e/release-env.yml
+++ b/src/jobs/e2e/release-env.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster in which the environment exists
-    default: "cm4-vf-dev-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p1"
 steps:
   - install-vfcli:
       init-cluster: << parameters.cluster >>

--- a/src/jobs/e2e/run-e2e-tests.yml
+++ b/src/jobs/e2e/run-e2e-tests.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster to create the environment on
-    default: "cm4-vf-dev-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p1"
   artifacts_path:
     description: The path within the repo where the e2e test artifacts will be stored
     type: string


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-1156**

### Brief description. What is this change?

- Run E2E in brazil by default
- Print pods on failure

### Tests

- Success https://app.circleci.com/pipelines/github/voiceflow/creator-app/180643/workflows/768b3762-7ef7-421b-b4de-93493d9b11af

- Failed run

https://app.circleci.com/pipelines/github/voiceflow/creator-app/180705/workflows/09db07b6-9ed5-4401-a9b3-b34c3e702c96/jobs/790276

![Screenshot 2024-01-08 at 4 06 44 PM](https://github.com/voiceflow/orb-common/assets/34867186/2bdc11c5-db95-4d86-999e-530ffb57e30f)
