### PR TITLE
fix:use correct base revision:IN-1116

### DIFF
--- a/src/commands/monorepo/set-service-data-json.yml
+++ b/src/commands/monorepo/set-service-data-json.yml
@@ -42,7 +42,7 @@ steps:
             COMPONENT_NAME=$(jq --raw-output ".serviceName" $DIRECTORY/$SERVICE/package.json)
             DOCKERFILE=$(jq --raw-output ".dockerfile" $DIRECTORY/$SERVICE/package.json)
 
-            echo "Adding $SERVICE to << parameters.json-file >>"
+            echo "Adding $SERVICE to << parameters.json-file >> with modified=$MODIFIED"
             jq --argjson modified "$MODIFIED" --arg dockerfile "$DOCKERFILE" --arg name "$SERVICE" --arg component_name "$COMPONENT_NAME" --arg directory "$DIRECTORY" '.<< parameters.field >> += [{name: $name, modified: $modified, component_name: $component_name, directory: $directory, dockerfile: $dockerfile}]' << parameters.json-file >> > << parameters.json-file >>.tmp
             mv << parameters.json-file >>.tmp << parameters.json-file >>
           done

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -22,7 +22,6 @@ steps:
         # If we are on master, use the previous commit as the base
         if [[ $GIT_BRANCH == "trying" ] || [ $GIT_BRANCH == "staging" ]]; then
           BASE="master"
-        fi
-        
+        fi        
         echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"  
         echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -16,12 +16,12 @@ steps:
       name: Put computed base revision in << parameters.target_env_var >> environment variable
       environment:
         BASE_REVISION: '<< parameters.base_revision >>'
-        GIT_BRANCH:    '<< parameters.git_branch >>'
+        GIT_BRANCH: '<< parameters.git_branch >>'
       command: |
         BASE="$BASE_REVISION"
         # If we are on master, use the previous commit as the base
         if [[ $GIT_BRANCH == "trying" ] || [ $GIT_BRANCH == "staging" ]]; then
           BASE="master"
-        fi        
-        echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"  
+        fi
+        echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"
         echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -1,0 +1,28 @@
+parameters:
+  base_revision:
+    description: Git revision to compare against
+    type: string
+    default: master
+  git_branch:
+    description: Current git branch
+    type: string
+    default: master
+  target_env_var:
+    description: Environment variable to set with the list of changed files
+    type: env_var_name
+    default: COMPUTED_BASE_REVISION
+steps:
+  - run:
+      name: Put computed base revision in << parameters.target_env_var >> environment variable
+      environment:
+        BASE_REVISION: '<< parameters.base_revision >>'
+        GIT_BRANCH:    '<< parameters.git_branch >>'
+      command: |
+        BASE="$BASE_REVISION"
+        # If we are on master, use the previous commit as the base
+        if [[ $GIT_BRANCH == "trying" ] || [ $GIT_BRANCH == "staging" ]]; then
+          BASE="master"
+        fi
+        
+        echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"  
+        echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -20,7 +20,7 @@ steps:
       command: |
         BASE="$BASE_REVISION"
         # If we are on master, use the previous commit as the base
-        if [[ $GIT_BRANCH == "trying" ] || [ $GIT_BRANCH == "staging" ]]; then
+        if [[ $GIT_BRANCH == "trying" ]] || [[ $GIT_BRANCH == "staging" ]]; then
           BASE="master"
         fi
         echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"

--- a/src/commands/utils/get_changed_files.yml
+++ b/src/commands/utils/get_changed_files.yml
@@ -12,7 +12,7 @@ steps:
           echo "Computed base revision is empty.Using default base revision of master"
        else
           BASE_REVISION="$COMPUTED_BASE_REVISION"
-          echo "Setting base revision to computed base revision: $BASE_REVISION"  
+          echo "Setting base revision to computed base revision: $BASE_REVISION"
        fi
        BASE="$(git merge-base $CIRCLE_SHA1 $BASE_REVISION)"
         # If we are on master, use the previous commit as the base

--- a/src/commands/utils/get_changed_files.yml
+++ b/src/commands/utils/get_changed_files.yml
@@ -1,4 +1,4 @@
-parameters: 
+parameters:
   target_env_var:
     description: Environment variable to set with the list of changed files
     type: env_var_name
@@ -14,11 +14,10 @@ steps:
           BASE_REVISION="$COMPUTED_BASE_REVISION"
           echo "Setting base revision to computed base revision: $BASE_REVISION"         
        fi
-
-        BASE="$(git merge-base $CIRCLE_SHA1 $BASE_REVISION)"
+       BASE="$(git merge-base $CIRCLE_SHA1 $BASE_REVISION)"
         # If we are on master, use the previous commit as the base
-        if [[ $BASE == $CIRCLE_SHA1 ]]; then
+       if [[ $BASE == $CIRCLE_SHA1 ]]; then
           BASE="$(git rev-parse HEAD~1)"
-        fi
-        FILE_CHANGES="$(git diff --name-status --no-commit-id -r $BASE...$CIRCLE_SHA1)"
-        echo "export << parameters.target_env_var >>=\"$FILE_CHANGES\"" >> "$BASH_ENV"
+       fi
+       FILE_CHANGES="$(git diff --name-status --no-commit-id -r $BASE...$CIRCLE_SHA1)"
+       echo "export << parameters.target_env_var >>=\"$FILE_CHANGES\"" >> "$BASH_ENV"

--- a/src/commands/utils/get_changed_files.yml
+++ b/src/commands/utils/get_changed_files.yml
@@ -1,8 +1,4 @@
-parameters:
-  base_revision:
-    description: Git revision to compare against
-    type: string
-    default: master
+parameters: 
   target_env_var:
     description: Environment variable to set with the list of changed files
     type: env_var_name
@@ -10,9 +6,15 @@ parameters:
 steps:
   - run:
       name: Put list of changed files in << parameters.target_env_var >> environment variable
-      environment:
-        BASE_REVISION: '<< parameters.base_revision >>'
       command: |
+       if [[ -z $COMPUTED_BASE_REVISION  ]]; then
+          BASE_REVISION="master"
+          echo "Computed base revision is empty.Using default base revision of master"
+       else
+          BASE_REVISION="$COMPUTED_BASE_REVISION"
+          echo "Setting base revision to computed base revision: $BASE_REVISION"         
+       fi
+
         BASE="$(git merge-base $CIRCLE_SHA1 $BASE_REVISION)"
         # If we are on master, use the previous commit as the base
         if [[ $BASE == $CIRCLE_SHA1 ]]; then

--- a/src/commands/utils/get_changed_files.yml
+++ b/src/commands/utils/get_changed_files.yml
@@ -12,7 +12,7 @@ steps:
           echo "Computed base revision is empty.Using default base revision of master"
        else
           BASE_REVISION="$COMPUTED_BASE_REVISION"
-          echo "Setting base revision to computed base revision: $BASE_REVISION"         
+          echo "Setting base revision to computed base revision: $BASE_REVISION"  
        fi
        BASE="$(git merge-base $CIRCLE_SHA1 $BASE_REVISION)"
         # If we are on master, use the previous commit as the base


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-1116**

### Brief description. What is this change?

- We are noticing that for mono repos, if a PR is not the first in a list of commits to master, when the merge to production is done, the changes for that PR are not being included in the docker images being built.
- The issue was that all branches were comparing their latest changes to the latest master.
- The fix is to use the previous CI pipeline's git revision to get the changed files and if the previous revision is not available 
     use the current revision
-  For `staging` and `trying` branches use master as base revision since the PR changes were created from master 

### Related PR
* https://github.com/voiceflow/creator-app/pull/7679
### Tests

- [x]  Tested with bors branches 
    * Base revision for `trying` and `staging` resolves to master
![image](https://github.com/voiceflow/orb-common/assets/127775867/7c8aa664-0788-456e-8579-6bfa49096e9a)

- [x] Tested with non bors branches 
![image](https://github.com/voiceflow/orb-common/assets/127775867/ac26e110-c6df-487f-9cbd-890e2ac35016)

* Current run refers to previous run showing that  base revision for non Bors branches resolves to the previous build SHA

![image](https://github.com/voiceflow/orb-common/assets/127775867/7440c1f7-bfbb-49d9-940d-6e18177b60bd)

- [x]  Tested new comment added so that we know if a service has changes or not.Previous comment implied services had 
          changes when they didnt have changes 
![image](https://github.com/voiceflow/orb-common/assets/127775867/539f94e8-9eda-45f6-8d73-3fef15a4061c)
