### PR TITLE
fix: cater for edge case base branches that dont exist:IN-1116

### DIFF
--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -22,6 +22,9 @@ steps:
         # If we are on master, use the previous commit as the base
         if [[ $GIT_BRANCH == "trying" ]] || [[ $GIT_BRANCH == "staging" ]]; then
           BASE="master"
+        # When a rebase and force push occurs on a branch, the previous run's branch is deleted and no longer exists
+        # For renovate builds, they are also short lived and branch is deleted
+        # In both cases, we want to use master as the base revision.The logic below checks if the base revision still exists and if not, uses master as the base revision
         else
           if [ -z "$(git rev-list $GIT_BRANCH  | grep $BASE_REVISION 2> /dev/null)" ]; then
               echo "Computed base revision for branch $GIT_BRANCH is empty.Using default base revision of master"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -22,6 +22,11 @@ steps:
         # If we are on master, use the previous commit as the base
         if [[ $GIT_BRANCH == "trying" ]] || [[ $GIT_BRANCH == "staging" ]]; then
           BASE="master"
+        else        
+          if [ -z "$(git rev-list $GIT_BRANCH  | grep $BASE_REVISION 2> /dev/null)" ]; then
+              echo "Computed base revision for branch $GIT_BRANCH is empty.Using default base revision of master"  
+              BASE="master"
+          fi 
         fi
         echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"
         echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -22,11 +22,11 @@ steps:
         # If we are on master, use the previous commit as the base
         if [[ $GIT_BRANCH == "trying" ]] || [[ $GIT_BRANCH == "staging" ]]; then
           BASE="master"
-        else        
+        else
           if [ -z "$(git rev-list $GIT_BRANCH  | grep $BASE_REVISION 2> /dev/null)" ]; then
-              echo "Computed base revision for branch $GIT_BRANCH is empty.Using default base revision of master"  
+              echo "Computed base revision for branch $GIT_BRANCH is empty.Using default base revision of master"
               BASE="master"
-          fi 
+          fi
         fi
         echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"
         echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* IN-1116

### Brief description. What is this change?

* Cater for base branches that expire or when we rebase and the ancestor of current branch changes from what it was.

### Related PR 

https://github.com/voiceflow/creator-app/pull/7703

#### Tests

- [x]  See related PR 