### PR TITLE
feat: make smoke tests run in parallel (DX-988)

### DIFF
--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -2,9 +2,13 @@ executor: smoke-executor
 parallelism: 4
 
 parameters:
-  env-name:
+  e2e-env-name:
     type: string
     default: ""
+  target-url:
+    type: string
+    default: ""
+    description: "use this to override the e2e-env-name and set the full creator-app URL"
   branch:
     type: string
     default: "master"
@@ -25,7 +29,7 @@ steps:
   - run:
       name: Run Smoke Tests
       environment:
-        CREATOR_APP_URL: https://creator-<< parameters.env-name >>.br.development.voiceflow.com
+        CREATOR_APP_URL: << parameters.target-url >><<^ parameters.target-url >>https://creator-<< parameters.e2e-env-name >>.br.development.voiceflow.com<</ parameters.target-url >>
         CYPRESS_INCLUDE_TAGS: << parameters.tags >>
         QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
       command: yarn test:smoke

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -9,9 +9,10 @@ parameters:
     type: string
     default: ""
     description: "use this to override the e2e-env-name and set the full creator-app URL"
-  branch:
+  branch-or-commit:
     type: string
     default: "master"
+    description: "the branch or commit of the automated-testing repo to checkout"
   tags:
     type: string
     default: ""
@@ -21,7 +22,7 @@ parameters:
 steps:
   - clone_repo:
       github_repo_name: automated-testing
-      github_commit: << parameters.branch >>
+      github_commit: << parameters.branch-or-commit >>
       path_to_clone: ~/project
   - install_node_modules:
       avoid_post_install_scripts: false

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -1,4 +1,5 @@
 executor: smoke-executor
+parallelism: 4
 
 parameters:
   env-name:
@@ -6,7 +7,13 @@ parameters:
     default: ""
   branch:
     type: string
+    default: "master"
+  tags:
+    type: string
     default: ""
+  qualitywatcher:
+    type: boolean
+    default: false
 steps:
   - clone_repo:
       github_repo_name: automated-testing
@@ -19,6 +26,8 @@ steps:
       name: Run Smoke Tests
       environment:
         CREATOR_APP_URL: https://creator-<< parameters.env-name >>.br.development.voiceflow.com
+        CYPRESS_INCLUDE_TAGS: << parameters.tags >>
+        QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
       command: yarn test:smoke
   - store_test_results:
       path: apps/smoke-test-runner/cypress/results


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-988**

### Brief description. What is this change?

Update smoke tests to run in parallel
I had originally thought that it wasn't possible because sorry cypress is no longer supported with cypress 13+
but we found a NEW work around with [cypress-split](https://www.npmjs.com/package/cypress-split) 💪

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test