### PR TITLE
feat: docker buildx for target stages (PL-664)

### DIFF
--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -32,6 +32,10 @@ parameters:
     description: Run in background
     type: boolean
     default: false
+  cleanup_image:
+    description: Delete the resulting image so it isn't stored in cache
+    type: boolean
+    default: false
 
 steps:
   - run:
@@ -46,4 +50,5 @@ steps:
         NO_CACHE_FILTER: "<< parameters.no_cache_filter >>"
         # possibly set as repo/branch/pr?
         BUILDER: "<< parameters.builder >>"
+        CLEANUP_IMAGE: "<< parameters.cleanup_image >>"
       command: <<include(scripts/docker/staged_buildx.sh)>>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -40,6 +40,14 @@ parameters:
     description: should probably be workspace
     type: string
     default: ""
+  output:
+    description: Buildx build --output flag
+    type: string
+    default: ''
+  enable_cache_to:
+    description: use --cache-to flag to push cache artifact to remote registry
+    type: boolean
+    default: false
   pre_steps:
     description: pre steps
     type: steps
@@ -65,5 +73,6 @@ steps:
         CLEANUP_IMAGE: "<< parameters.cleanup_image >>"
         PACKAGE: "<< parameters.package >>"
         OUTPUT: "<< parameters.output >>"
+        ENABLE_CACHE_TO: "<< parameters.enable_cache_to >>"
       command: <<include(scripts/docker/staged_buildx.sh)>>
   - steps: << parameters.post_steps >>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -24,6 +24,11 @@ parameters:
       Consider this the key for CircleCI DLC
     type: string
     default: ""
+  no_cache_filter:
+    description: Do not use cache for these stages
+    type: string
+    default: ""
+
 steps:
   - run:
       name: Building '<<parameters.target >>' stage of file '<< parameters.dockerfile >>' with tag '<< parameters.image_tag >>'
@@ -33,6 +38,7 @@ steps:
         IMAGE_TAG: "<< parameters.image_tag >>"
         PLATFORMS: "<< parameters.platforms >>"
         DOCKERFILE: "<< parameters.dockerfile >>"
+        NO_CACHE_FILTER: "<< parameters.no_cache_filter >>"
         # possibly set as repo/branch/pr?
         BUILDER: "<< parameters.builder >>"
       command: <<include(scripts/docker/staged_buildx.sh)>>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -40,10 +40,22 @@ parameters:
     description: should probably be workspace
     type: string
     default: ""
-
+  output:
+    description: output type
+    type: string
+    default: "--load"
+  pre_steps:
+    description: pre steps
+    type: steps
+    default: []
+  post_steps:
+    description: post steps
+    type: steps
+    default: []
 steps:
+  - steps: << parameters.pre_steps >>
   - run:
-      name: Building '<<parameters.target >>' stage of file '<< parameters.dockerfile >>' with tag '<< parameters.image_tag >>'
+      name: Building '<< parameters.target >>' stage of file '<< parameters.dockerfile >>' with tag '<< parameters.image_tag >>'
       background: << parameters.run_in_background >>
       environment:
         TARGET: "<< parameters.target >>"
@@ -56,4 +68,6 @@ steps:
         BUILDER: "<< parameters.builder >>"
         CLEANUP_IMAGE: "<< parameters.cleanup_image >>"
         PACKAGE: "<< parameters.package >>"
+        OUTPUT: << parameters.output >>
       command: <<include(scripts/docker/staged_buildx.sh)>>
+  - steps: << parameters.post_steps >>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -28,10 +28,15 @@ parameters:
     description: Do not use cache for these stages
     type: string
     default: ""
+  run_in_background:
+    description: Run in background
+    type: boolean
+    default: false
 
 steps:
   - run:
       name: Building '<<parameters.target >>' stage of file '<< parameters.dockerfile >>' with tag '<< parameters.image_tag >>'
+      background: << parameters.run_in_background >>
       environment:
         TARGET: "<< parameters.target >>"
         IMAGE_REPO: "<< parameters.image_repo >>"

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -39,7 +39,7 @@ parameters:
   output:
     description: Buildx build --output flag
     type: string
-    default: ''
+    default: ""
   enable_cache_to:
     description: use --cache-to flag to push cache artifact to remote registry
     type: boolean

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -1,0 +1,38 @@
+parameters:
+  image_repo:
+    description: The container image repository
+    type: string
+  image_tag:
+    description: The container image tag
+    type: string
+    default: ""
+  target:
+    description: Dockerfile stage to build
+    type: string
+  platforms:
+    description: Platform to build against
+    type: string
+    default: "linux/amd64"
+    # default: "linux/amd64,linux/arm64"
+  dockerfile:
+    description: Location of Dockerfile
+    type: string
+    default: "Dockerfile"
+  builder:
+    description: |
+      Buildx builder name
+      Consider this the key for CircleCI DLC
+    type: string
+    default: ""
+steps:
+  - run:
+      name: Building '<<parameters.target >>' stage of file '<< parameters.dockerfile >>' with tag '<< parameters.image_tag >>'
+      environment:
+        TARGET: "<< parameters.target >>"
+        IMAGE_REPO: "<< parameters.image_repo >>"
+        IMAGE_TAG: "<< parameters.image_tag >>"
+        PLATFORMS: "<< parameters.platforms >>"
+        DOCKERFILE: "<< parameters.dockerfile >>"
+        # possibly set as repo/branch/pr?
+        BUILDER: "<< parameters.builder >>"
+      command: <<include(scripts/docker/staged_buildx.sh)>>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -40,10 +40,6 @@ parameters:
     description: should probably be workspace
     type: string
     default: ""
-  output:
-    description: output type
-    type: string
-    default: "--load"
   pre_steps:
     description: pre steps
     type: steps
@@ -68,6 +64,6 @@ steps:
         BUILDER: "<< parameters.builder >>"
         CLEANUP_IMAGE: "<< parameters.cleanup_image >>"
         PACKAGE: "<< parameters.package >>"
-        OUTPUT: << parameters.output >>
+        OUTPUT: "<< parameters.output >>"
       command: <<include(scripts/docker/staged_buildx.sh)>>
   - steps: << parameters.post_steps >>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -36,6 +36,10 @@ parameters:
     description: Delete the resulting image so it isn't stored in cache
     type: boolean
     default: false
+  package:
+    description: should probably be workspace
+    type: string
+    default: ""
 
 steps:
   - run:
@@ -51,4 +55,5 @@ steps:
         # possibly set as repo/branch/pr?
         BUILDER: "<< parameters.builder >>"
         CLEANUP_IMAGE: "<< parameters.cleanup_image >>"
+        PACKAGE: "<< parameters.package >>"
       command: <<include(scripts/docker/staged_buildx.sh)>>

--- a/src/commands/docker/staged_buildx.yml
+++ b/src/commands/docker/staged_buildx.yml
@@ -32,10 +32,6 @@ parameters:
     description: Run in background
     type: boolean
     default: false
-  cleanup_image:
-    description: Delete the resulting image so it isn't stored in cache
-    type: boolean
-    default: false
   package:
     description: should probably be workspace
     type: string
@@ -70,7 +66,6 @@ steps:
         NO_CACHE_FILTER: "<< parameters.no_cache_filter >>"
         # possibly set as repo/branch/pr?
         BUILDER: "<< parameters.builder >>"
-        CLEANUP_IMAGE: "<< parameters.cleanup_image >>"
         PACKAGE: "<< parameters.package >>"
         OUTPUT: "<< parameters.output >>"
         ENABLE_CACHE_TO: "<< parameters.enable_cache_to >>"

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -79,6 +79,10 @@ parameters:
     description: Platform to build the image
     type: string
     default: linux/amd64
+  enable_dlc:
+    description: enable docker layer cache
+    type: boolean
+    default: false
 steps:
   - when:
       condition: << parameters.checkout >>
@@ -92,6 +96,7 @@ steps:
       steps:
         - setup_remote_docker: # Need this to run DinD
             version: << parameters.remote_docker_version >>
+            docker_layer_caching: << parameters.enable_dlc >>
   - docker_login
   - attach_workspace:
       at: ~/voiceflow

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -83,6 +83,10 @@ parameters:
     description: enable docker layer cache
     type: boolean
     default: false
+  builder_name:
+    description: named builder for use with DLC
+    type: string
+    default: ""
 steps:
   - when:
       condition: << parameters.checkout >>
@@ -132,4 +136,5 @@ steps:
         INJECT_AWS_CREDENTIALS: "<< parameters.inject_aws_credentials >>"
         USE_BUILDKIT: "<< parameters.use_buildkit >>"
         PLATFORM: "<< parameters.platform >>"
+        BUILDER_NAME: "<< parameters.builder_name >>"
       command: <<include(scripts/track/update_track.sh)>>

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -87,6 +87,10 @@ parameters:
     description: enable docker layer cache
     type: boolean
     default: false
+  builder_name:
+    description: named builder for use with DLC
+    type: string
+    default: ""
 steps:
   - update_track:
       image_repo: "<< parameters.image_repo >>"
@@ -110,3 +114,4 @@ steps:
       use_buildkit: "<< parameters.use_buildkit >>"
       platform: "<< parameters.platform >>"
       enable_dlc: "<< parameters.enable_dlc >>"
+      builder_name: "<< parameters.builder_name >>"

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -83,6 +83,10 @@ parameters:
     description: Platform to build the image for
     type: string
     default: linux/amd64
+  enable_dlc:
+    description: enable docker layer cache
+    type: boolean
+    default: false
 steps:
   - update_track:
       image_repo: "<< parameters.image_repo >>"
@@ -105,3 +109,4 @@ steps:
       local_registry_container_image: "<< parameters.local_registry_container_image >>"
       use_buildkit: "<< parameters.use_buildkit >>"
       platform: "<< parameters.platform >>"
+      enable_dlc: "<< parameters.enable_dlc >>"

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -7,6 +7,7 @@ echo "IMAGE_TAG: ${IMAGE_TAG:=${TARGET}}"
 echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
 echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
 echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
+echo "CLEANUP_IMAGE: ${CLEANUP_IMAGE:=0}"
 
 
 # NOTE: think of this as the CircleCI DLC key
@@ -28,3 +29,5 @@ docker buildx build . \
   --target "${TARGET}" \
   --platform "${PLATFORMS}" \
   --load
+
+test "${CLEANUP_IMAGE-}" -eq 1 && echo "Deleting image" && docker image rm "${IMAGE_REPO}:${IMAGE_TAG}" || echo "Done"

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -17,6 +17,10 @@ echo "PACKAGE: ${PACKAGE-}"
 # NOTE: think of this as the CircleCI DLC key
 echo "BUILDER: ${BUILDER:=buildy}"
 
+# shellcheck source=/dev/null
+for i in /tmp/vf-staged_buildx-*.env_var ; do source "$i" ; done
+echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
+
 # This is specific
 echo "NPM_TOKEN: ${NPM_TOKEN#"//registry.npmjs.org/:_authToken="}"
 # TODO: make file secret ~/.yarnrc.yml,target=$HOME/.yarnrc.yml
@@ -40,9 +44,10 @@ docker buildx build . \
   -f "${DOCKERFILE}" \
   -t "${IMAGE_REPO}:${IMAGE_TAG}" \
   "${PACKAGE_ARG[@]}" \
+  "${EXTRA_BUILD_ARGS[@]}" \
   --secret id=NPM_TOKEN \
   --target "${TARGET}" \
   --platform "${PLATFORMS}" \
-  ${OUTPUT[@]}
+  "${OUTPUT[@]}"
 
 test "${CLEANUP_IMAGE-}" -eq 1 && echo "Deleting image" && docker image rm "${IMAGE_REPO}:${IMAGE_TAG}" || echo "Done"

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -9,6 +9,9 @@ echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
 echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
 echo "CLEANUP_IMAGE: ${CLEANUP_IMAGE:=0}"
 
+# TODO: should be general build-args
+echo "PACKAGE: ${PACKAGE-}"
+
 
 # NOTE: think of this as the CircleCI DLC key
 echo "BUILDER: ${BUILDER:=buildy}"
@@ -22,9 +25,14 @@ docker buildx inspect "${BUILDER}" >/dev/null 2>&1 || docker buildx create --pla
 docker buildx use "${BUILDER}"
 docker buildx inspect --bootstrap
 
+if [[ -n "$PACKAGE" ]]; then
+    PACKAGE_ARG=(--build-arg APP_NAME="$PACKAGE")
+fi
+
 docker buildx build . \
   -f "${DOCKERFILE}" \
   -t "${IMAGE_REPO}:${IMAGE_TAG}" \
+  "${PACKAGE_ARG[@]}" \
   --secret id=NPM_TOKEN \
   --target "${TARGET}" \
   --platform "${PLATFORMS}" \

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Expected env vars
+echo "TARGET: ${TARGET:=prod}"
+echo "IMAGE_REPO: ${IMAGE_REPO?}"
+echo "IMAGE_TAG: ${IMAGE_TAG:=${TARGET}}"
+echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
+echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
+
+# NOTE: think of this as the CircleCI DLC key
+echo "BUILDER: ${BUILDER:=buildy}"
+
+# This is specific
+echo "NPM_TOKEN: ${NPM_TOKEN#"//registry.npmjs.org/:_authToken="}"
+# TODO: make file secret ~/.yarnrc.yml,target=$HOME/.yarnrc.yml
+# TODO: extensible secrets and build args
+
+docker buildx inspect "${BUILDER}" >/dev/null 2>&1 || docker buildx create --platform="${PLATFORMS}" --name "${BUILDER}"
+docker buildx use "${BUILDER}"
+docker buildx inspect --bootstrap
+
+docker buildx build . \
+  -f "${DOCKERFILE}" \
+  -t "${IMAGE_REPO}:${IMAGE_TAG}" \
+  --secret id=NPM_TOKEN \
+  --target "${TARGET}" \
+  --platform "${PLATFORMS}" \
+  --load

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Expected env vars
 echo "TARGET: ${TARGET:=prod}"

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -6,6 +6,8 @@ echo "IMAGE_REPO: ${IMAGE_REPO?}"
 echo "IMAGE_TAG: ${IMAGE_TAG:=${TARGET}}"
 echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
 echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
+echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
+
 
 # NOTE: think of this as the CircleCI DLC key
 echo "BUILDER: ${BUILDER:=buildy}"

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Expected env vars
-echo "TARGET: ${TARGET:=prod}"
+echo "TARGET: ${TARGET:=runner}"
 echo "IMAGE_REPO: ${IMAGE_REPO?}"
 echo "IMAGE_TAG: ${IMAGE_TAG:=${TARGET}}"
 echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
 echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
-echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
+echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=runner}"
 echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
 
 # TODO: should be general build-args

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -8,6 +8,7 @@ echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
 echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
 echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
 echo "CLEANUP_IMAGE: ${CLEANUP_IMAGE:=0}"
+echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
 
 # TODO: should be general build-args
 echo "PACKAGE: ${PACKAGE-}"
@@ -17,7 +18,8 @@ echo "PACKAGE: ${PACKAGE-}"
 echo "BUILDER: ${BUILDER:=buildy}"
 
 # shellcheck source=/dev/null
-for i in /tmp/vf-staged_buildx-*.env_var ; do source "$i" ; done
+test -n "$(shopt -s nullglob; echo /tmp/vf-staged_buildx-*.env_var)" \
+  && for i in /tmp/vf-staged_buildx-*.env_var ; do source "$i" ; done
 echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
 
 if [ -z "${OUTPUT-}" ] ; then
@@ -28,13 +30,33 @@ fi
 
 echo "OUTPUT: ${OUTPUT_ARG[*]}"
 
+if [[ -z "$CIRCLE_BRANCH" && -n "$CIRCLE_TAG" ]]; then
+    BRANCH_NAME="master"
+else
+    BRANCH_NAME="${CIRCLE_BRANCH//[^[:alnum:]]/-}" # Change all non alphanumeric characters to -
+fi
+
+IMAGE_CACHE_TAG_BASE="${IMAGE_REPO-}:cache-${BRANCH_NAME-}"
+
+CACHE_FROM_ARG=(--cache-from "${IMAGE_REPO-}:cache-master")
+
+if [ "${BRANCH_NAME}" != "master" ] ; then
+  CACHE_FROM_ARG+=(--cache-from "${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
+fi
+
+if [ "${ENABLE_CACHE_TO-}" = "true" ] ; then
+  CACHE_TO_ARG=(--cache-to "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${IMAGE_CACHE_TAG_BASE}-${IMAGE_TAG-}")
+fi
+
+
 # This is specific
 echo "NPM_TOKEN: ${NPM_TOKEN#"//registry.npmjs.org/:_authToken="}"
 # TODO: make file secret ~/.yarnrc.yml,target=$HOME/.yarnrc.yml
 # TODO: extensible secrets and build args
 
 docker buildx inspect "${BUILDER}" >/dev/null 2>&1 || docker buildx create --platform="${PLATFORMS}" --name "${BUILDER}"
-docker buildx inspect --bootstrap --use "${BUILDER}"
+docker buildx use "${BUILDER-}"
+docker buildx inspect --bootstrap
 
 if [[ -n "$PACKAGE" ]]; then
     PACKAGE_ARG=(--build-arg APP_NAME="$PACKAGE")
@@ -45,6 +67,8 @@ docker buildx build . \
   -t "${IMAGE_REPO}:${IMAGE_TAG}" \
   "${PACKAGE_ARG[@]}" \
   "${EXTRA_BUILD_ARGS[@]}" \
+  "${CACHE_FROM_ARG[@]}" \
+  "${CACHE_TO_ARG[@]}" \
   --secret id=NPM_TOKEN \
   --target "${TARGET}" \
   --platform "${PLATFORMS}" \

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -8,6 +8,7 @@ echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
 echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
 echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
 echo "CLEANUP_IMAGE: ${CLEANUP_IMAGE:=0}"
+echo "OUTPUT: ${OUTPUT-}"
 
 # TODO: should be general build-args
 echo "PACKAGE: ${PACKAGE-}"
@@ -29,6 +30,12 @@ if [[ -n "$PACKAGE" ]]; then
     PACKAGE_ARG=(--build-arg APP_NAME="$PACKAGE")
 fi
 
+if [ -n "$OUTPUT" ] ; then
+  OUTPUT=(--output "${OUTPUT}")
+else
+  OUTPUT=(--load)
+fi
+
 docker buildx build . \
   -f "${DOCKERFILE}" \
   -t "${IMAGE_REPO}:${IMAGE_TAG}" \
@@ -36,6 +43,6 @@ docker buildx build . \
   --secret id=NPM_TOKEN \
   --target "${TARGET}" \
   --platform "${PLATFORMS}" \
-  --load
+  ${OUTPUT[@]}
 
 test "${CLEANUP_IMAGE-}" -eq 1 && echo "Deleting image" && docker image rm "${IMAGE_REPO}:${IMAGE_TAG}" || echo "Done"

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -13,8 +13,6 @@ echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
 echo "PACKAGE: ${PACKAGE-}"
 
 
-# NOTE: think of this as the CircleCI DLC key
-echo "BUILDER: ${BUILDER:=buildy}"
 
 # shellcheck source=/dev/null
 test -n "$(shopt -s nullglob; echo /tmp/vf-staged_buildx-*.env_var)" \
@@ -35,7 +33,8 @@ else
     BRANCH_NAME="${CIRCLE_BRANCH//[^[:alnum:]]/-}" # Change all non alphanumeric characters to -
 fi
 
-IMAGE_CACHE_TAG_BASE="${IMAGE_REPO-}:cache-${BRANCH_NAME-}"
+# NOTE: think of this as the CircleCI DLC key
+echo "BUILDER: ${BUILDER:=buildy-${BRANCH_NAME-}}"
 
 CACHE_FROM_ARG=(--cache-from "${IMAGE_REPO-}:cache-master")
 
@@ -43,8 +42,9 @@ if [ "${BRANCH_NAME}" != "master" ] ; then
   CACHE_FROM_ARG+=(--cache-from "${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
 fi
 
+IMAGE_CACHE_TAG_BASE="${IMAGE_REPO-}:cache-${BRANCH_NAME-}"
 if [ "${ENABLE_CACHE_TO-}" = "true" ] ; then
-  CACHE_TO_ARG=(--cache-to "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${IMAGE_CACHE_TAG_BASE}-${IMAGE_TAG-}")
+  CACHE_TO_ARG=(--cache-to "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${IMAGE_CACHE_TAG_BASE}")
 fi
 
 

--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -7,7 +7,6 @@ echo "IMAGE_TAG: ${IMAGE_TAG:=${TARGET}}"
 echo "PLATFORMS: ${PLATFORMS:=linux/amd64}"
 echo "DOCKERFILE: ${DOCKERFILE:=Dockerfile}"
 echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=prod}"
-echo "CLEANUP_IMAGE: ${CLEANUP_IMAGE:=0}"
 echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
 
 # TODO: should be general build-args
@@ -73,5 +72,3 @@ docker buildx build . \
   --target "${TARGET}" \
   --platform "${PLATFORMS}" \
   "${OUTPUT_ARG[@]}"
-
-test "${CLEANUP_IMAGE-}" -eq 1 && echo "Deleting image" && docker image rm "${IMAGE_REPO}:${IMAGE_TAG}" || echo "Done"

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -15,6 +15,7 @@ echo "DOCKERFILE: ${DOCKERFILE?}"
 echo "INJECT_AWS_CREDENTIALS: ${INJECT_AWS_CREDENTIALS?}"
 echo "PLATFORM: ${PLATFORM?}"
 echo "USE_BUILDKIT: ${USE_BUILDKIT?}"
+echo "BUILDER_NAME: ${BUILDER_NAME-}"
 
 # Load IMAGE_EXISTS variable from file previously stored in the tmp folder
 # shellcheck disable=SC1091
@@ -78,7 +79,11 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
 
     BUILD_COMMAND="build"
     if (( USE_BUILDKIT )); then
-        docker buildx create --use --platform="$PLATFORM"
+        if [[ -n "${BUILDER_NAME-}" ]]; then
+          BUILDER_ARGS=(--name "${BUILDER_NAME-}")
+        fi
+        docker buildx create --use --platform="$PLATFORM" \
+          "${BUILDER_ARGS[@]}"
         docker buildx inspect --bootstrap
         BUILD_COMMAND="buildx build --load"
         NPM_TOKEN_SECRET=(--secret id=NPM_TOKEN)

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -81,6 +81,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
         docker buildx create --use --platform="$PLATFORM"
         docker buildx inspect --bootstrap
         BUILD_COMMAND="buildx build --load"
+        NPM_TOKEN_SECRET=(--secret id=NPM_TOKEN)
     fi
     
     docker $BUILD_COMMAND \
@@ -92,6 +93,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
         "${REGISTRY_ARG[@]}" \
         "${PACKAGE_ARG[@]}" \
         "${AWS_CREDENTIALS_ARG[@]}" \
+        "${NPM_TOKEN_SECRET[@]}" \
         $BUILD_ARGS \
         --platform "$PLATFORM" \
         -f "$BUILD_CONTEXT/$DOCKERFILE" \


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-664**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Add step to target a stage of a Dockerfile in buildx

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Want to bring forward our usage of Docker/buildkit toolings and features with more control/split ownership of building between dev and infra

Remote Cache Registry:
- Default naming scheme is `<image repo>:cache-<branch>`
- Default cache-from: current branch cache and master cache
- Only allow 1 cache per branch
  - likely needs a way to cleanup the remote cache after it's been merged and built on master, if the storage is an issue

DLC:
- Default builder name is `builder-<branch>` as a key

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/creator-api/pull/1406