### PR TITLE
fix: use correct base revision for branches:IN-1173

### DIFF
--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -23,7 +23,7 @@ steps:
         # Master branch has multiple PR's merged into it independently before the `branch-sync` to production occurs.
         # After sync, the 2 branches are a mirror of each other because the current SHA for production is similar to the SHA for master branch
         # In the case where the SHA's are the same, we then do a diff between HEAD and HEAD~1, which discards all other changes
-        # Using latest master as base revision for production would cause us to skip detecting all changes that occured in the multiple PR's merged, for monorepos
+        # Using latest master as base revision for production would cause us to skip detecting all other changes except HEAD~1 up to HEAD, for monorepos
         # The fix is to use the base revision as the commit of the previous circleci build on production branch, ensuring that all changes are detected
         # Circleci exposes the last build's commit as an environment variable `pipeline.git.base_revision` which is paased to this command as `base_revision` parameter
         if [[ $GIT_BRANCH == "production" ]] ; then

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -18,18 +18,16 @@ steps:
         BASE_REVISION: '<< parameters.base_revision >>'
         GIT_BRANCH: '<< parameters.git_branch >>'
       command: |
-        BASE="$BASE_REVISION"
-        # If we are on master, use the previous commit as the base
-        if [[ $GIT_BRANCH == "trying" ]] || [[ $GIT_BRANCH == "staging" ]]; then
-          BASE="master"
-        # When a rebase and force push occurs on a branch, the previous run's branch is deleted and no longer exists
-        # For renovate builds, they are also short lived and branch is deleted
-        # In both cases, we want to use master as the base revision.The logic below checks if the base revision still exists and if not, uses master as the base revision
-        else
-          if [ -z "$(git rev-list $GIT_BRANCH  | grep $BASE_REVISION 2> /dev/null)" ]; then
-              echo "Computed base revision for branch $GIT_BRANCH is empty.Using default base revision of master"
-              BASE="master"
-          fi
+        # For all branches that are created, eg for review envs, normal PR's,branch rebases,bors trying/staging and renovate builds, use master as the base revision; except for production
+        BASE="master"
+        # Master branch has multiple PR's merged into it independently before the `branch-sync` to production occurs.
+        # After sync, the 2 branches are a mirror of each other because the current SHA for production is similar to the SHA for master branch
+        # In the case where the SHA's are the same, we then do a diff between HEAD and HEAD~1, which discards all other changes
+        # Using latest master as base revision for production would cause us to skip detecting all changes that occured in the multiple PR's merged, for monorepos
+        # The fix is to use the base revision as the commit of the previous circleci build on production branch, ensuring that all changes are detected
+        # Circleci exposes the last build's commit as an environment variable `pipeline.git.base_revision` which is paased to this command as `base_revision` parameter
+        if [[ $GIT_BRANCH == "production" ]] ; then
+          BASE="$BASE_REVISION"
         fi
         echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"
         echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -18,10 +18,10 @@ steps:
         BASE_REVISION: '<< parameters.base_revision >>'
         GIT_BRANCH: '<< parameters.git_branch >>'
       command: |
-        # For all branches: 
+        # For all branches:
         # For review envs, normal PR's,branch rebases,bors trying/staging and renovate builds, use master as the base revision; except for production
         BASE="master"
-        # For production branch: 
+        # For production branch:
         # Multiple PR's are merged into it master independently before the `branch-sync` to production occurs.
         # After sync, the 2 branches are a mirror of each other because the current SHA for production is similar to the SHA for master branch
         # In the case where the SHA's are the same, we then do a diff between HEAD and HEAD~1, which discards all other changes

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -18,14 +18,16 @@ steps:
         BASE_REVISION: '<< parameters.base_revision >>'
         GIT_BRANCH: '<< parameters.git_branch >>'
       command: |
-        # For all branches that are created, eg for review envs, normal PR's,branch rebases,bors trying/staging and renovate builds, use master as the base revision; except for production
+        # For all branches: 
+        # For review envs, normal PR's,branch rebases,bors trying/staging and renovate builds, use master as the base revision; except for production
         BASE="master"
-        # Master branch has multiple PR's merged into it independently before the `branch-sync` to production occurs.
+        # For production branch: 
+        # Multiple PR's are merged into it master independently before the `branch-sync` to production occurs.
         # After sync, the 2 branches are a mirror of each other because the current SHA for production is similar to the SHA for master branch
         # In the case where the SHA's are the same, we then do a diff between HEAD and HEAD~1, which discards all other changes
         # Using latest master as base revision for production would cause us to skip detecting all other changes except HEAD~1 up to HEAD, for monorepos
         # The fix is to use the base revision as the commit of the previous circleci build on production branch, ensuring that all changes are detected
-        # Circleci exposes the last build's commit as an environment variable `pipeline.git.base_revision` which is paased to this command as `base_revision` parameter
+        # Circleci exposes the last build's commit as an environment variable `pipeline.git.base_revision` which is passed to this command as `base_revision` parameter
         if [[ $GIT_BRANCH == "production" ]] ; then
           BASE="$BASE_REVISION"
            echo "Setting base revision to  $BASE_REVISION for $GIT_BRANCH"

--- a/src/commands/utils/compute_base_revision.yml
+++ b/src/commands/utils/compute_base_revision.yml
@@ -28,6 +28,7 @@ steps:
         # Circleci exposes the last build's commit as an environment variable `pipeline.git.base_revision` which is paased to this command as `base_revision` parameter
         if [[ $GIT_BRANCH == "production" ]] ; then
           BASE="$BASE_REVISION"
+           echo "Setting base revision to  $BASE_REVISION for $GIT_BRANCH"
         fi
         echo "COMPUTED_BASE_REVISION environment variable to set to $BASE"
         echo "export << parameters.target_env_var >>=\"$BASE\"" >> "$BASH_ENV"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* https://voiceflow.atlassian.net/browse/IN-1173

### Brief description. What is this change?

* Use correct base revision for branches 

### Implementation details. How do you make this change?

*   For all branches that are created, eg for review envs, normal PR's,branch rebases,bors trying/staging and renovate builds, use master as the base revision; except for production
* Master branch has multiple PR's merged into it independently before the `branch-sync` to production occurs.
 * After sync, the 2 branches are a mirror of each other because the current SHA for production is similar to the SHA for master branch
 * In the case where the SHA's are the same, we then do a diff between HEAD and HEAD~1, which discards all other changes
  * Using latest master as base revision for production would cause us to skip detecting all changes that occured in the multiple PR's merged, causing us to only consider the previous commit and current for monorepos
  * The fix is to use the base revision as the commit of the previous circleci build on production branch, ensuring that all changes are detected
  * Circleci exposes the last build's commit as an environment variable `pipeline.git.base_revision` which is paased to this command as `base_revision` parameter

### Related PRs

* https://github.com/voiceflow/orb-common/pull/191

- https://github.com/voiceflow/orb-common/pull/190

### Checklist

- [x] Tested dev ORB for trying, staging and PR branches 
- [x] Tested this ORB using creator-app PR https://github.com/voiceflow/creator-app/pull/7758
- [x] [PR branch build ](https://app.circleci.com/pipelines/github/voiceflow/creator-app?branch=edison%2Fuse_correct_base_revision%2FIN-1173)
- [x] [Trying build ](https://app.circleci.com/pipelines/github/voiceflow/creator-app?branch=trying )