### PR TITLE
fix: use arm executor to stabilize function-lambda build:IN-1175

### DIFF
--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -28,6 +28,7 @@ parameters:
     default: true
   remote_docker_version:
     description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
+    # https://circleci.com/docs/building-docker-images/#docker-version
     type: string
     default: "20.10.11"
   bucket:

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -86,7 +86,7 @@ steps:
       condition: << parameters.request_remote_docker >>
       steps:
         - setup_remote_docker: # Need this to run DinD
-            version: 20.10.11
+            version: default
   - docker_login
   - attach_workspace:
       at: ~/voiceflow

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -26,6 +26,11 @@ parameters:
     description: Add the option to request a new remote docker, set to false when you concat docker jobs
     type: boolean
     default: true
+  remote_docker_version:
+    description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
+    # https://circleci.com/docs/building-docker-images/#docker-version
+    type: string
+    default: 20.10.11
   bucket:
     description: The container image repository
     type: string
@@ -86,7 +91,7 @@ steps:
       condition: << parameters.request_remote_docker >>
       steps:
         - setup_remote_docker: # Need this to run DinD
-            version: default
+            version: << parameters.remote_docker_version >>
   - docker_login
   - attach_workspace:
       at: ~/voiceflow

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -28,7 +28,6 @@ parameters:
     default: true
   remote_docker_version:
     description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
-    # https://circleci.com/docs/building-docker-images/#docker-version
     type: string
     default: 20.10.11
   bucket:

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -29,7 +29,7 @@ parameters:
   remote_docker_version:
     description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
     type: string
-    default: 20.10.11
+    default: "20.10.11"
   bucket:
     description: The container image repository
     type: string

--- a/src/executors/lambda/lambda-executor.yml
+++ b/src/executors/lambda/lambda-executor.yml
@@ -1,0 +1,8 @@
+parameters:
+  default_resource_class:
+    description: Default resource class for the executor
+    type: string
+    default: arm.medium
+docker:
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-lambda:3.10.13-node
+resource_class: << parameters.default_resource_class >>

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -30,6 +30,10 @@ parameters:
     description: "Add the option to request a new remote docker, set to false when you concat docker jobs"
     type: boolean
     default: true
+  remote_docker_version:
+    description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
+    type: string
+    default: "20.10.11"
   bucket:
     description: The container image repository
     type: string
@@ -87,6 +91,7 @@ steps:
       build_context: "<< parameters.build_context >>"
       checkout: "<< parameters.checkout >>"
       request_remote_docker: "<< parameters.request_remote_docker >>"
+      remote_docker_version: "<< parameters.remote_docker_version >>"
       bucket: "<< parameters.bucket >>"
       check_track_exists: "<< parameters.check_track_exists >>"
       local_registry: "<< parameters.local_registry >>"

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -32,6 +32,7 @@ parameters:
     default: true
   remote_docker_version:
     description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
+    # https://circleci.com/docs/building-docker-images/#docker-version
     type: string
     default: "20.10.11"
   bucket:

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -82,7 +82,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
         docker buildx inspect --bootstrap
         BUILD_COMMAND="buildx build --load"
     fi
-
+    
     docker $BUILD_COMMAND \
         --build-arg build_BUILD_NUM="${CIRCLE_BUILD_NUM}" \
         --build-arg build_GITHUB_TOKEN="${GITHUB_TOKEN}" \
@@ -96,6 +96,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
         --platform "$PLATFORM" \
         -f "$BUILD_CONTEXT/$DOCKERFILE" \
         -t "$IMAGE_NAME" "$BUILD_CONTEXT"
+    echo "BUILD_ARGS: $BUILD_ARGS $PLATFORM"    
     docker push "$IMAGE_NAME"
 
     # Signing Docker Image


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* https://voiceflow.atlassian.net/browse/IN-1175

### Brief description. What is this change?

* function-lambda builds are unstable and this is to rectify that issue 


### Implementation details. How do you make this change?

* Use arm executors and target arm when building 


### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/orb-common/pull/194/files
- https://github.com/voiceflow/creator-api/pull/1406

### Checklist

- [x] Changes tested in PR build 
- https://app.circleci.com/pipelines/github/voiceflow/function-lambda?branch=edison/stabilize-lambda-function-builds/IN-1175