### PR TITLE
fix: switch to default docker

### DIFF
--- a/src/commands/docker/build_push_image.yml
+++ b/src/commands/docker/build_push_image.yml
@@ -66,7 +66,7 @@ steps:
       condition: << parameters.request_remote_docker >>
       steps:
         - setup_remote_docker:  # Need this to run DinD
-            version: 20.10.11
+            version: default
   - attach_workspace:
       at: ~/voiceflow
   - docker_login

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -30,7 +30,7 @@ parameters:
     description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
     # https://circleci.com/docs/building-docker-images/#docker-version
     type: string
-    default: "20.10.11"
+    default: "default"
   bucket:
     description: The container image repository
     type: string

--- a/src/commands/utils/check_image_exists.yml
+++ b/src/commands/utils/check_image_exists.yml
@@ -12,7 +12,7 @@ steps:
       condition: << parameters.request_remote_docker >>
       steps:
         - setup_remote_docker:  # Need this to run DinD
-            version: 20.10.11
+            version: default
   - docker_login
   - run:
       name: If container with this git SHA already exists, don't build

--- a/src/commands/yarn/yarn_command.yml
+++ b/src/commands/yarn/yarn_command.yml
@@ -69,7 +69,7 @@ steps:
       condition: << parameters.request_remote_docker >>
       steps:
         - setup_remote_docker:  # Need this to run DinD
-            version: 20.10.11
+            version: default
   - when:
       condition: << parameters.run_in_container >>
       steps:

--- a/src/jobs/monorepo/monorepo_schema_validate.yml
+++ b/src/jobs/monorepo/monorepo_schema_validate.yml
@@ -18,7 +18,7 @@ parameters:
 executor: << parameters.executor >>
 steps:
   - setup_remote_docker:
-      version: 20.10.11
+      version: default
   - checkout
   - install_node_modules:
       avoid_post_install_scripts: false

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -34,7 +34,7 @@ parameters:
     description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
     # https://circleci.com/docs/building-docker-images/#docker-version
     type: string
-    default: "20.10.11"
+    default: "default"
   bucket:
     description: The container image repository
     type: string


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

Due to the fact that Circleci is removing ld versions of Linux images, it seems that it will remove old versions of remote docker executors: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

### Implementation details. How do you make this change?

The recommendation is to use default and edge. I think default is more than enough for now

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test