### PR TITLE
feat: add stable-only flag to smoke test job (DX-1559)

### DIFF
--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -19,6 +19,9 @@ parameters:
   qualitywatcher:
     type: boolean
     default: false
+  stable-only:
+    type: boolean
+    default: true
 steps:
   - clone_repo:
       github_repo_name: automated-testing
@@ -33,7 +36,7 @@ steps:
         CREATOR_APP_URL: << parameters.target-url >><<^ parameters.target-url >>https://creator-<< parameters.e2e-env-name >>.br.development.voiceflow.com<</ parameters.target-url >>
         CYPRESS_INCLUDE_TAGS: << parameters.tags >>
         QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
-      command: yarn test:smoke
+      command: yarn test:smoke<<# parameters.stable-only >>:stable<</ parameters.stable-only >>
   - store_test_results:
       path: apps/smoke-test-runner/cypress/results
   - store_artifacts:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-1559**

### Brief description. What is this change?

Add a `stable-only` flag to the smoke test job which defaults to `true`
When enabled it filters to only run tests in the `cypress/integration/stable/` folder by executing the `test:smoke:stable` job

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test