### PR TITLE
fix: force EXTRA_BUILD_ARGS from string to array

### DIFF
--- a/src/scripts/docker/staged_buildx.sh
+++ b/src/scripts/docker/staged_buildx.sh
@@ -10,6 +10,9 @@ echo "NO_CACHE_FILTER: ${NO_CACHE_FILTER:=runner}"
 echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
 echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
 
+# force string to array
+read -r -a EXTRA_BUILD_ARGS <<< "$EXTRA_BUILD_ARGS"
+
 if [ -z "${OUTPUT-}" ] ; then
   OUTPUT_ARG=(--load)
 else

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -17,6 +17,9 @@ echo "USE_BUILDKIT: ${USE_BUILDKIT?}"
 echo "BUILDER_NAME: ${BUILDER_NAME-}"
 echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
 
+# force string to array
+read -r -a EXTRA_BUILD_ARGS <<< "$EXTRA_BUILD_ARGS"
+
 # Load IMAGE_EXISTS variable from file previously stored in the tmp folder
 # shellcheck disable=SC1091
 source "/tmp/IMAGE_STATUS"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

CircleCI doesn't like arrays especially when passing to scripts through env vars. pass as string and force cast to array through use of `read -a`