### PR TITLE
feat: optionall install dependencies before scanning

### DIFF
--- a/src/jobs/monorepo/sonarcloud_scan.yml
+++ b/src/jobs/monorepo/sonarcloud_scan.yml
@@ -3,10 +3,18 @@ parameters:
     description: Executor to run the command on
     type: executor
     default: java-executor
+  install_node_modules:
+    description: Install dependencies before scanning
+    type: boolean
+    default: false
 executor: << parameters.executor >>
 steps:
   - checkout
   - attach_workspace:
       at: ~/voiceflow
+  - when:
+      condition: << parameters.install_node_modules >>
+      steps:
+        - install_node_modules
   - sonarcloud/scan:
       cache_version: 2


### PR DESCRIPTION
### Brief description. What is this change?

I think sonar needs this since the `tsconfig.json` now relies on a dependency that needs to be installed first
<img width="634" alt="Screenshot 2024-04-11 at 12 33 43" src="https://github.com/voiceflow/orb-common/assets/3784470/4d2cf46f-905b-4507-a6c8-4c62a27b60dd">

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test