### PR TITLE
fix: set network timeout to 35 seconds for prepublish (PL-000)

### DIFF
--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -51,6 +51,7 @@ steps:
               # Git user must be set for yarn publish
               git config --global user.email "serviceaccount@voiceflow.com"
               git config --global user.name "Voiceflow"
+              yarn config set network-timeout 35000 -g
               yarn publish --new-version << parameters.prerelease_version >> --tag << parameters.prerelease_tag >>
   - unless:
       condition: << parameters.prerelease_version >>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
release is timing out on publish for pre-release, increase network timeout to 35 seconds