### PR TITLE
fix: use image with upgraded semantic release:IN-992

### DIFF
--- a/src/executors/node/default-executor-node-20.yml
+++ b/src/executors/node/default-executor-node-20.yml
@@ -5,7 +5,7 @@ parameters:
     default: medium
 working_directory: ~/voiceflow
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v3
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v5
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/src/executors/node/node-executor-node-20.yml
+++ b/src/executors/node/node-executor-node-20.yml
@@ -9,7 +9,7 @@ parameters:
     default: '4096'
 working_directory: ~/voiceflow
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v3
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v5
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/src/executors/node/node-large-executor-node-20.yml
+++ b/src/executors/node/node-large-executor-node-20.yml
@@ -9,7 +9,7 @@ parameters:
     default: "4096"
 working_directory: ~/voiceflow
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v3
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v5
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 

* Linear [ticket](https://linear.app/voiceflow/issue/IN-992/resolve-semantic-release-issues-for-database-cli) 

### Brief description. What is this change?
* Upgrade semantic release from version 17 to version 23 to resolve the issue where builds fail 
   * https://github.com/semantic-release/semantic-release/issues/793 
* Create new node 20 image with the latest semantic release version
* Point the node 20 executors to use the new image

### Checklist 
- [ ] Breaking changes have been communicated, including:
