### PR TITLE
fix: add ssh key to release job:IN-992

### DIFF
--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -32,7 +32,14 @@ parameters:
     description: Tag to use for prerelease (Must be used alongside prerelease_version)
     type: string
     default: ""
+  ssh_key:
+    description: The SSH key with write permissions to the repository
+    type: string
+    default: ""
 steps:
+  - add_ssh_keys:
+      fingerprints:
+        - "<< parameters.ssh_key >>"
   - checkout
   - install_node_modules:
       install_args: "<< parameters.install_args >>"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [ticket](https://linear.app/voiceflow/issue/IN-992/resolve-semantic-release-issues-for-database-cli) 

### Brief description. What is this change?

* Resolve semantic release failures for database-cli repo.

### Implementation details. How do you make this change?

* Propagate and use an ssh key during the build, that has write access 

### Checklist

- [ ] Tested on poc repository 
  * https://app.circleci.com/pipelines/github/voiceflow/poc-dbcli-semantic-release/33/workflows/5ca5f28c-5370-4266-a87e-ee7ac068a989