### PR TITLE
fix: cached smoke tests (IN-1000)

### DIFF
--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -30,6 +30,11 @@ steps:
   - install_node_modules:
       avoid_post_install_scripts: false
       cache_prefix: smoke-test
+  - monorepo_restore_cache:
+      package: "all"
+      package_folder: "{apps,libs}"
+      monorepo_engine: "turborepo"
+      cache_branch: "master"
   - run:
       name: Run Smoke Tests
       environment:
@@ -37,6 +42,11 @@ steps:
         CYPRESS_INCLUDE_TAGS: << parameters.tags >>
         QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
       command: yarn test:smoke<<# parameters.stable-only >>:stable<</ parameters.stable-only >>
+  - monorepo_save_cache:
+      package: "all"
+      package_folder: "{apps,libs}"
+      monorepo_engine: "turborepo"
+      cache_branch: "master"
   - store_test_results:
       path: apps/smoke-test-runner/cypress/results
   - store_artifacts:

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -35,6 +35,7 @@ steps:
       package_folder: "{apps,libs}"
       monorepo_engine: "turborepo"
       cache_branch: "master"
+      cache_identifier: "smoke-test-build-cache"
   - run:
       name: Run Smoke Tests
       environment:
@@ -47,6 +48,7 @@ steps:
       package_folder: "{apps,libs}"
       monorepo_engine: "turborepo"
       cache_branch: "master"
+      cache_identifier: "smoke-test-build-cache"
   - store_test_results:
       path: apps/smoke-test-runner/cypress/results
   - store_artifacts:

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -30,12 +30,8 @@ steps:
   - install_node_modules:
       avoid_post_install_scripts: false
       cache_prefix: smoke-test
-  - monorepo_restore_cache:
-      package: "all"
-      package_folder: "{apps,libs}"
-      monorepo_engine: "turborepo"
-      cache_branch: "master"
-      cache_identifier: "smoke-test-build-cache"
+  - restore_cache:
+      key: "smoke-test-build-cache"
   - run:
       name: Run Smoke Tests
       environment:
@@ -43,12 +39,10 @@ steps:
         CYPRESS_INCLUDE_TAGS: << parameters.tags >>
         QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
       command: yarn test:smoke<<# parameters.stable-only >>:stable<</ parameters.stable-only >>
-  - monorepo_save_cache:
-      package: "all"
-      package_folder: "{apps,libs}"
-      monorepo_engine: "turborepo"
-      cache_branch: "master"
-      cache_identifier: "smoke-test-build-cache"
+  - save_cache:
+      key: "smoke-test-build-cache"
+      paths:
+        - node_modules/.cache/turbo
   - store_test_results:
       path: apps/smoke-test-runner/cypress/results
   - store_artifacts:


### PR DESCRIPTION
Test caching the turborepo build of the smoke test.

No cache:
<img width="421" alt="Screenshot 2024-04-25 at 4 58 02 PM" src="https://github.com/voiceflow/orb-common/assets/5643574/72f32129-fc88-4bc4-840f-c47d88389b44">


With cache:
<img width="424" alt="Screenshot 2024-04-25 at 4 57 14 PM" src="https://github.com/voiceflow/orb-common/assets/5643574/e3eb1448-aa03-4135-aa50-ea46b2ef66e5">

Tested on this PR:
https://github.com/voiceflow/creator-app/pull/8027