### PR TITLE
fix: clear turborepo cache (IN-1002)

### DIFF
--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -46,10 +46,10 @@ steps:
             condition:
               equal: ["turborepo", << parameters.monorepo_engine >>]
             steps:
-              - persist_to_workspace:
-                  root: "."
-                  paths:
-                    - node_modules/.cache/turbo
+              - run:
+                  name: Clean up the cache directory
+                  # deletes all files in the cache directory that are older than 7 days, only mtime is persisted properly
+                  command: find node_modules/.cache/turbo -type f -mtime +7 -delete
               - save_cache:
                   paths:
                     - node_modules/.cache/turbo

--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -47,8 +47,8 @@ steps:
               equal: ["turborepo", << parameters.monorepo_engine >>]
             steps:
               - run:
-                  name: Clean up the cache directory
                   # deletes all files in the cache directory that are older than 7 days, only mtime is persisted properly
+                  name: Clean cache directory
                   command: find node_modules/.cache/turbo -type f -mtime +7 -delete
               - save_cache:
                   paths:


### PR DESCRIPTION
this is a limited solution until turborepo offers a proper way to know which cache actually got used as part of a job 
(we could do a super shitty grep of the output logs, but it's extremely janky)
https://github.com/vercel/turbo/discussions/7450

Just delete all cache files over 7 days old.

Tested this on an ssh'ed container, goes from 2.4GB -> ~150MB.

We also don't need to persist turborepo to the workspace.
![image](https://github.com/voiceflow/orb-common/assets/5643574/89aaaa5c-6c0c-45c9-9b5a-2524405ed864)
![image](https://github.com/voiceflow/orb-common/assets/5643574/b0dd32f4-598b-465f-9c8e-9ca6cafbf4f9)
