### PR TITLE
fix: tie to commit hashes (IN-1000)

### DIFF
--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -31,7 +31,7 @@ steps:
       avoid_post_install_scripts: false
       cache_prefix: smoke-test
   - run:
-      name: "Derive commit SHA"
+      name: "Reference commit SHA"
       command: echo "SMOKE_TEST_COMMIT_SHA=$(git rev-parse HEAD)" >> $BASH_ENV
   - restore_cache:
       # use the commit of the smoke-test-runner repo as the cache key

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -32,10 +32,10 @@ steps:
       cache_prefix: smoke-test
   - run:
       name: "Reference commit SHA"
-      command: echo "SMOKE_TEST_COMMIT_SHA=$(git rev-parse HEAD)" >> $BASH_ENV
+      command: echo "SMOKE_TEST_COMMIT_SHA=$(git rev-parse HEAD)" >> commit.txt
   - restore_cache:
       # use the commit of the smoke-test-runner repo as the cache key
-      key: "smoke-test-build-cache-${SMOKE_TEST_COMMIT_SHA}"
+      key: smoke-test-build-cache-{{ checksum "commit.txt" }}
   - run:
       name: Run Smoke Tests
       environment:
@@ -44,7 +44,7 @@ steps:
         QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
       command: yarn test:smoke<<# parameters.stable-only >>:stable<</ parameters.stable-only >>
   - save_cache:
-      key: "smoke-test-build-cache-${SMOKE_TEST_COMMIT_SHA}"
+      key: smoke-test-build-cache-{{ checksum "commit.txt" }}
       paths:
         - node_modules/.cache/turbo
   - store_test_results:

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -1,5 +1,5 @@
 executor: smoke-executor
-parallelism: 4
+parallelism: 5
 
 parameters:
   e2e-env-name:

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -1,5 +1,5 @@
 executor: smoke-executor
-parallelism: 5
+parallelism: 4
 
 parameters:
   e2e-env-name:
@@ -32,7 +32,7 @@ steps:
       cache_prefix: smoke-test
   - run:
       name: "Reference commit SHA"
-      command: echo "SMOKE_TEST_COMMIT_SHA=$(git rev-parse HEAD)" >> commit.txt
+      command: git rev-parse HEAD >> commit.txt
   - restore_cache:
       # use the commit of the smoke-test-runner repo as the cache key
       key: smoke-test-build-cache-{{ checksum "commit.txt" }}

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -30,8 +30,12 @@ steps:
   - install_node_modules:
       avoid_post_install_scripts: false
       cache_prefix: smoke-test
+  - run:
+      name: "Derive commit SHA"
+      command: echo "SMOKE_TEST_COMMIT_SHA=$(git rev-parse HEAD)" >> $BASH_ENV
   - restore_cache:
-      key: "smoke-test-build-cache"
+      # use the commit of the smoke-test-runner repo as the cache key
+      key: "smoke-test-build-cache-${SMOKE_TEST_COMMIT_SHA}"
   - run:
       name: Run Smoke Tests
       environment:
@@ -40,7 +44,7 @@ steps:
         QUALITYWATCHER_ENABLED: << parameters.qualitywatcher >>
       command: yarn test:smoke<<# parameters.stable-only >>:stable<</ parameters.stable-only >>
   - save_cache:
-      key: "smoke-test-build-cache"
+      key: "smoke-test-build-cache-${SMOKE_TEST_COMMIT_SHA}"
       paths:
         - node_modules/.cache/turbo
   - store_test_results:


### PR DESCRIPTION
I realized with circleci's caching system, once `smoke-test-build-cache` is set, it will never be cleared again.

So even if there is a new build and the cache changed, it will not save anything. 
![Screenshot 2024-04-28 at 11 46 54 PM](https://github.com/voiceflow/orb-common/assets/5643574/8e0108ed-0ec9-45c0-9a0c-80e0c2d33b63)

Instead we need to use the commit SHA of the smoke-test git project as a marker for the cache.

Tested on this branch in creator-app:
https://github.com/voiceflow/creator-app/pull/8049

I have to save the commit into a file and use the checksum. Reference relevant files:
https://devops.stackexchange.com/questions/9147/how-to-get-other-than-no-value-when-interpolating-environment-some-var/9177
https://discuss.circleci.com/t/interpolating-environment-some-var-after-setting-some-var-results-in-no-value/32352
https://discuss.circleci.com/t/setting-environment-variable-from-script-command-for-later-use-in-cache-name/24036/2