### PR TITLE
fix: cache cypress build (IN-1004)

### DIFF
--- a/src/commands/yarn/vf_save_cache.yml
+++ b/src/commands/yarn/vf_save_cache.yml
@@ -14,3 +14,4 @@ steps:
         - << parameters.working_directory >>/.yarn/cache
         - << parameters.working_directory >>/.yarn/install-state.gz
         - << parameters.working_directory >>/node_modules
+        - ~/.cache/Cypress

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -29,7 +29,6 @@ steps:
       path_to_clone: ~/project
   - install_node_modules:
       avoid_post_install_scripts: false
-      cache_prefix: smoke-test
   - run:
       name: "Reference commit SHA"
       command: git rev-parse HEAD >> commit.txt


### PR DESCRIPTION
This is recommended by cypress:
https://docs.cypress.io/guides/continuous-integration/introduction#Caching

<img width="1417" alt="Screenshot 2024-04-29 at 5 20 59 PM" src="https://github.com/voiceflow/orb-common/assets/5643574/559bae27-03ec-482b-836d-f5c032ef05d8">

There are some issues if we don't cache it. Tested on:
https://github.com/voiceflow/automated-testing/pull/167
