### PR TITLE
fix: resolve linting issues (IN-1006)

### DIFF
--- a/src/commands/utils/checkout_shallow_clone.yml
+++ b/src/commands/utils/checkout_shallow_clone.yml
@@ -35,7 +35,7 @@ steps:
   - run:
       name: << parameters.step_name >>
       background: << parameters.run_in_background >>
-      # The first command is a shallow clone of the repo where we use depth = 1 
+      # The first command is a shallow clone of the repo where we use depth = 1
       # https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
       # -b flag is used to specify the branch to clone
       # In circleci we checkout code either from branches or tags, so we use the branch if it exists, otherwise the tag

--- a/src/commands/utils/checkout_shallow_clone.yml
+++ b/src/commands/utils/checkout_shallow_clone.yml
@@ -51,3 +51,4 @@ steps:
       command: |
         git clone --depth=1 -b ${<< parameters.github_branch >>:-${<< parameters.github_tag >>:?}} https://${<< parameters.github_username >>}:${<< parameters.github_token >>}@github.com/voiceflow/${<< parameters.github_repo_name >>} << parameters.path_to_clone >>
         git fetch origin master --depth=2
+        

--- a/src/commands/utils/checkout_shallow_clone.yml
+++ b/src/commands/utils/checkout_shallow_clone.yml
@@ -51,4 +51,3 @@ steps:
       command: |
         git clone --depth=1 -b ${<< parameters.github_branch >>:-${<< parameters.github_tag >>:?}} https://${<< parameters.github_username >>}:${<< parameters.github_token >>}@github.com/voiceflow/${<< parameters.github_repo_name >>} << parameters.path_to_clone >>
         git fetch origin master --depth=2
-        


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [IN-1006 ](https://linear.app/voiceflow/issue/IN-1006/use-shallow-clone-instead-of-checkout)

### Brief description. What is this change?
* We can speed up builds by up to and shave off 30 seconds, eg for repos like creator-app 
* Where it takes 30 seconds to clone, it will now take 1 second 
### Implementation details. How do you make this change?
* Do shallow clones for both branches and tags 

### Notion page 
*  [ notion link](https://www.notion.so/voiceflow/Shallow-clone-across-all-repos-9e4f6402bcbe4f3f925f583c61c0ec82) 

### Checklist (Tested on repos) 

- [ ] Tested on various repos 