### PR TITLE
fix: dont use shallow cloning for track  updates (IN-1006)

### DIFF
--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -95,7 +95,7 @@ steps:
   - when:
       condition: << parameters.checkout >>
       steps:
-        - checkout # special step to check out source code to working directory
+        - checkout # special step to check out source code to working directory.
         - run:
             name: "Get latest tags"
             command: git pull || echo "Nothing to pull"

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -95,7 +95,7 @@ steps:
   - when:
       condition: << parameters.checkout >>
       steps:
-        - checkout_shallow_clone # special step to check out source code to working directory
+        - checkout # special step to check out source code to working directory
         - run:
             name: "Get latest tags"
             command: git pull || echo "Nothing to pull"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [ticket](https://linear.app/voiceflow/issue/IN-1006/use-shallow-clone-instead-of-checkout) 

### Brief description. What is this change?

* Dont use shallow cloning for track updates
* Track updating checks tags and branches and needs to do several comparisons in its logic 
* We are noticing intermittent failures when some of the tags that have been pulled don't have corresponding commits 


### Example failing build 

- circle-ci [build](https://app.circleci.com/pipelines/github/voiceflow/creator-app/196117/workflows/91c5f140-2eb3-4108-86fc-1396948ac64d/jobs/851702) 

### Checklist

- [x] This is reverting a previously working change, so we know it was working before 
