### PR TITLE
fix: checkout last 10 commits

### DIFF
--- a/src/commands/utils/checkout_shallow_clone.yml
+++ b/src/commands/utils/checkout_shallow_clone.yml
@@ -44,10 +44,10 @@ steps:
       # There will always be one of them set at any given time and the other one will be empty
       # These have been defined as parameters to allow for easy customization
       # We use bash conditionals to check if the branch is set, otherwise use the tag environment variable.If both are not set then fail
-      # The second command checks out the previous 2 commits of master.
+      # The second command checks out the previous 10 commits of master.
       # Its not enough to shallow clone the most recent commit of your PR branch or tag, some tools we use for UI tests need master branch  (HEAD) and master -1 (HEAD^) to do certain comparisons
       # For repositories we can use shallow cloning, the 2 git commands below allow us to fetch the least amount of code that allows the pipeline to pass
       # Other considerations and exceptions can be found here https://www.notion.so/voiceflow/Shallow-clone-across-all-repos-9e4f6402bcbe4f3f925f583c61c0ec82
       command: |
         git clone --depth=1 -b ${<< parameters.github_branch >>:-${<< parameters.github_tag >>:?}} https://${<< parameters.github_username >>}:${<< parameters.github_token >>}@github.com/voiceflow/${<< parameters.github_repo_name >>} << parameters.path_to_clone >>
-        git fetch origin master --depth=2
+        git fetch origin master --depth=10


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

We have a shallow repository with only a single commit. We can verify by executing git rev-parse --is-shallow-repository.

HEAD^ points to the commit before our current commit – which does not exist in shallow clones of depth 1 and sometimes it does not exist in depth 2. We have to unshallow we clone or deepen it to include the commits which we are referencing.

For instance, to deepen our shallow clone to include the latest 10 commits, run git fetch --depth=10

https://github.com/voiceflow/creator-app/pull/8107


### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test