### PR TITLE
fix: use depth 2 on PR branches as well (IN-1054)

### DIFF
--- a/src/commands/utils/checkout_shallow_clone.yml
+++ b/src/commands/utils/checkout_shallow_clone.yml
@@ -35,7 +35,7 @@ steps:
   - run:
       name: << parameters.step_name >>
       background: << parameters.run_in_background >>
-      # The first command is a shallow clone of the repo where we use depth = 1
+      # The first command is a shallow clone of the repo where we use depth = 2
       # https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
       # -b flag is used to specify the branch to clone
       # In circleci we checkout code either from branches or tags, so we use the branch if it exists, otherwise the tag
@@ -49,5 +49,5 @@ steps:
       # For repositories we can use shallow cloning, the 2 git commands below allow us to fetch the least amount of code that allows the pipeline to pass
       # Other considerations and exceptions can be found here https://www.notion.so/voiceflow/Shallow-clone-across-all-repos-9e4f6402bcbe4f3f925f583c61c0ec82
       command: |
-        git clone --depth=1 -b ${<< parameters.github_branch >>:-${<< parameters.github_tag >>:?}} https://${<< parameters.github_username >>}:${<< parameters.github_token >>}@github.com/voiceflow/${<< parameters.github_repo_name >>} << parameters.path_to_clone >>
+        git clone --depth=2 -b ${<< parameters.github_branch >>:-${<< parameters.github_tag >>:?}} https://${<< parameters.github_username >>}:${<< parameters.github_token >>}@github.com/voiceflow/${<< parameters.github_repo_name >>} << parameters.path_to_clone >>
         git fetch origin master --depth=2

--- a/src/commands/utils/checkout_shallow_clone.yml
+++ b/src/commands/utils/checkout_shallow_clone.yml
@@ -42,7 +42,7 @@ steps:
       # In git both a branch and a tag are treated as a branch, so we take advantage of this to have one command for both
       # The circleci environment variable for current branch is CIRCLE_BRANCH, and for current tag is CIRCLE_TAG
       # There will always be one of them set at any given time and the other one will be empty
-      # These have been defined as parameters to allow for easy customization
+      # These have been defined as parameters to allow for easy customization.
       # We use bash conditionals to check if the branch is set, otherwise use the tag environment variable.If both are not set then fail
       # The second command checks out the previous 2 commits of master.
       # Its not enough to shallow clone the most recent commit of your PR branch or tag, some tools we use for UI tests need master branch  (HEAD) and master -1 (HEAD^) to do certain comparisons


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Fixes or implements 
* Linear [ticket](https://linear.app/voiceflow/issue/IN-1054/resolve-shallow-clone-issue-causing-creator-app-tests-to-fail) 

### Brief description. What is this change?
* Checkout PR branches at depth 2 as some of our git diff logic requires HEAD^ 


### Checklist

- [x] Tested on a failing PR 
 * https://github.com/voiceflow/creator-app/pull/8111