### PR TITLE
feat(update-track): allow push from build and cosign with manifests (PL-1056)

### DIFF
--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -79,8 +79,8 @@ parameters:
     description: Use buildkit to build the image
     type: boolean
     default: false
-  enable_push:
-    description: Push the built image into remote registry without loading to docker
+  enable_load:
+    description: Load image into local docker
     type: boolean
     default: false
   platform:
@@ -144,7 +144,7 @@ steps:
         DOCKERFILE: "<< parameters.dockerfile >>"
         INJECT_AWS_CREDENTIALS: "<< parameters.inject_aws_credentials >>"
         USE_BUILDKIT: "<< parameters.use_buildkit >>"
-        ENABLE_PUSH: "<< parameters.enable_push >>"
+        ENABLE_LOAD: "<< parameters.enable_load >>"
         PLATFORM: "<< parameters.platform >>"
         BUILDER_NAME: "<< parameters.builder_name >>"
       command: <<include(scripts/track/update_track.sh)>>

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -79,6 +79,10 @@ parameters:
     description: Use buildkit to build the image
     type: boolean
     default: false
+  enable_push:
+    description: Push the built image into remote registry without loading to docker
+    type: boolean
+    default: false
   platform:
     description: Platform to build the image
     type: string
@@ -140,6 +144,7 @@ steps:
         DOCKERFILE: "<< parameters.dockerfile >>"
         INJECT_AWS_CREDENTIALS: "<< parameters.inject_aws_credentials >>"
         USE_BUILDKIT: "<< parameters.use_buildkit >>"
+        ENABLE_PUSH: "<< parameters.enable_push >>"
         PLATFORM: "<< parameters.platform >>"
         BUILDER_NAME: "<< parameters.builder_name >>"
       command: <<include(scripts/track/update_track.sh)>>

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -75,10 +75,6 @@ parameters:
     description: container image to run verdaccio
     type: string
     default: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-build-image:v1
-  use_buildkit:
-    description: Use buildkit to build the image
-    type: boolean
-    default: false
   enable_load:
     description: Load image into local docker
     type: boolean
@@ -143,7 +139,6 @@ steps:
         ENABLE_CACHE_TO: "<< parameters.enable_cache_to >>"
         DOCKERFILE: "<< parameters.dockerfile >>"
         INJECT_AWS_CREDENTIALS: "<< parameters.inject_aws_credentials >>"
-        USE_BUILDKIT: "<< parameters.use_buildkit >>"
         ENABLE_LOAD: "<< parameters.enable_load >>"
         PLATFORM: "<< parameters.platform >>"
         BUILDER_NAME: "<< parameters.builder_name >>"

--- a/src/executors/node/build-executor.yml
+++ b/src/executors/node/build-executor.yml
@@ -5,7 +5,7 @@ parameters:
     default: medium
 working_directory: ~/voiceflow
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-image:v5
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-image:25.0.5-dind-vf-2
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -83,8 +83,8 @@ parameters:
     description: Use buildkit to build the image
     type: boolean
     default: false
-  enable_push:
-    description: Push the built image into remote registry without loading to docker
+  enable_load:
+    description: Load image into local docker
     type: boolean
     default: false
   platform:
@@ -123,5 +123,5 @@ steps:
       use_buildkit: "<< parameters.use_buildkit >>"
       platform: "<< parameters.platform >>"
       enable_dlc: "<< parameters.enable_dlc >>"
-      enable_push: "<< parameters.enable_push >>"
+      enable_load: "<< parameters.enable_load >>"
       builder_name: "<< parameters.builder_name >>"

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -83,6 +83,10 @@ parameters:
     description: Use buildkit to build the image
     type: boolean
     default: false
+  enable_push:
+    description: Push the built image into remote registry without loading to docker
+    type: boolean
+    default: false
   platform:
     description: Platform to build the image for
     type: string
@@ -119,4 +123,5 @@ steps:
       use_buildkit: "<< parameters.use_buildkit >>"
       platform: "<< parameters.platform >>"
       enable_dlc: "<< parameters.enable_dlc >>"
+      enable_push: "<< parameters.enable_push >>"
       builder_name: "<< parameters.builder_name >>"

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -79,10 +79,6 @@ parameters:
     description: container image to run verdaccio
     type: string
     default: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-build-image:v1
-  use_buildkit:
-    description: Use buildkit to build the image
-    type: boolean
-    default: false
   enable_load:
     description: Load image into local docker
     type: boolean
@@ -120,7 +116,6 @@ steps:
       kms_key: "<< parameters.kms_key >>"
       inject_aws_credentials: "<< parameters.inject_aws_credentials >>"
       local_registry_container_image: "<< parameters.local_registry_container_image >>"
-      use_buildkit: "<< parameters.use_buildkit >>"
       platform: "<< parameters.platform >>"
       enable_dlc: "<< parameters.enable_dlc >>"
       enable_load: "<< parameters.enable_load >>"

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -17,7 +17,7 @@ echo "USE_BUILDKIT: ${USE_BUILDKIT?}"
 echo "BUILDER_NAME: ${BUILDER_NAME-}"
 echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
 echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
-echo "ENABLE_PUSH: ${ENABLE_PUSH:=0}"
+echo "ENABLE_LOAD: ${ENABLE_LOAD:=0}"
 
 # force string to array
 read -r -a EXTRA_BUILD_ARGS <<< "$EXTRA_BUILD_ARGS"
@@ -97,10 +97,9 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
           "${BUILDER_ARGS[@]}"
         docker buildx inspect --bootstrap
 
-        if (( ENABLE_PUSH )); then
-          OUTPUT_ARGS=(--push)
-        else
-          OUTPUT_ARGS=(--load)
+        OUTPUT_ARGS=(--push)
+        if (( ENABLE_LOAD )); then
+          OUTPUT_ARGS+=(--load)
         fi
 
         NPM_TOKEN_SECRET=(--secret id=NPM_TOKEN)

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -116,6 +116,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
 
         BUILD_ARGS+=( "${CACHE_FROM_ARG[@]}" )
         BUILD_ARGS+=( "${CACHE_TO_ARG[@]}" )
+        BUILD_ARGS+=( --builder "${BUILDER_NAME-}")
     fi
 
     TAGS=(-t "$IMAGE_NAME")


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?
allow image push from build instead of converting and loading into docker locally
`cosign` with remote manifests on digest instead of labels

## Related PRs:
relies on `ci-image:25.0.5-dind-vf-2` , so will need additional monitoring on `update-track` runs 
- https://github.com/voiceflow/infrastructure/pull/668
- https://github.com/voiceflow/infrastructure/pull/670
- https://github.com/voiceflow/infrastructure/pull/671

Used in `VFML`:
- https://github.com/voiceflow/VFML/pull/623

### Tests:
successful builds in:
* [event-ingestion-service](https://github.com/voiceflow/event-ingestion-service/pull/62)
* [general-service](https://github.com/voiceflow/general-service/pull/580)
* [platform](https://github.com/voiceflow/platform/pull/1025)
* [general-runtime](https://github.com/voiceflow/general-runtime/pull/820)
* [creator-app](https://github.com/voiceflow/creator-app/pull/8144)
* [creator-api](https://github.com/voiceflow/creator-api/pull/1450)
