### PR TITLE
fix: increase the sleep time before it checks running jobs

### DIFF
--- a/src/jobs/e2e/waiter.yml
+++ b/src/jobs/e2e/waiter.yml
@@ -8,6 +8,6 @@ steps:
       ## it ends the loop and trigger the downstream job that depends on it
       while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CCI_Token"| jq -r '.items[]|select(.name != "vfcommon/waiter")|.status' | grep -c "running") -gt 0 ]]
         do
-          sleep 1
+          sleep 5
         done
   - run: echo "All required jobs have now completed"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

Noticed that it could take sometime before the next job in a pipeline starts. The waiter job currently sleeps for 1sec before checking again

If a job expected to run in the pipeline doesn't run in that 1second window, waiter sees the pipeline as completed


### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test