### PR TITLE
feat: improve smoke tests visibility (IN-1101)

### DIFF
--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -26,7 +26,6 @@ steps:
   - run:
       name: Gather Logs
       environment:
-        ENV_NAME: {{ .values.e2e_env_name }}
         LOG_DIR: &log_dir /tmp/pod-logs-{{ .values.e2e_env_name }}
       background: true
       command: |

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -24,13 +24,13 @@ steps:
   - restore_cache:
       key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   - run:
-    name: Create directories
-    environment:
-      LOG_DIR: &log_dir  /tmp/logs-<< parameters.e2e-env-name >>
-      COMPONENT_LOG_DIR: &component_log_dir component-logs
-      KUBE_STATE_DIR: &kube_state_dir kubernetes-state"
-    command: |
-      mkdir -p "${LOG_DIR:?}/{${component-logs:?},${kubernetes-state:?}}"
+      name: Create directories
+      environment:
+        LOG_DIR: &log_dir  /tmp/logs-<< parameters.e2e-env-name >>
+        COMPONENT_LOG_DIR: &component_log_dir component-logs
+        KUBE_STATE_DIR: &kube_state_dir kubernetes-state"
+      command: |
+        mkdir -p "${LOG_DIR:?}/{${component-logs:?},${kubernetes-state:?}}"
   - run:
       name: Gather Kubernetes state before run
       environment:

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -15,7 +15,7 @@ parameters:
       default: "/home/circleci/voiceflow/env_name.txt"
 steps:
   - install-vfcli:
-      init-cluster: << parameters.cluster >> 
+      init-cluster: << parameters.cluster >>
   - restore_cache:
       key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   - run:

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -40,11 +40,11 @@ steps:
       command: |
         echo "Contents of << parameters.env-name-path >>:"
         cat << parameters.env-name-path >>
-        if [[ -f << parameters.env-name-path >> ]]; then
-          DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
-        else
-          DEV_ENV_NAME=<< parameters.e2e-env-name >>
-        fi
+        if [ -f << parameters.env-name-path >> ] && [ "$(cat << parameters.env-name-path >> )" != "null" ]; then
+                DEV_ENV_NAME=$(cat << parameters.env-name-path >> )
+            else
+                DEV_ENV_NAME=<< parameters.e2e-env-name >>
+            fi
         # Gather summary state of all pods in the namespace
         echo "Gathering Kubernetes state before run for env $DEV_ENV_NAME"
         kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/pods-summary-state-before-run.log"
@@ -56,10 +56,8 @@ steps:
       background: true
       command: |
         function capture_logs() {
-            echo "Contents of << parameters.env-name-path >>:"
-              cat << parameters.env-name-path >>
-            if [[ -f << parameters.env-name-path >> ]]; then
-                DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
+            if [ -f << parameters.env-name-path >> ] && [ "$(cat << parameters.env-name-path >> )" != "null" ]; then
+                DEV_ENV_NAME=$(cat << parameters.env-name-path >> )
             else
                 DEV_ENV_NAME=<< parameters.e2e-env-name >>
             fi
@@ -76,7 +74,7 @@ steps:
             # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
             last_component=${components[${#components[@]}-1]}
             echo "Capturing logs for last component $last_component"
-            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>""${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log"
+            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log"
         }
         capture_logs
 
@@ -95,13 +93,11 @@ steps:
         LOG_DIR: *log_dir
         KUBE_STATE_DIR: *kube_state_dir
       command: |
-        echo "Contents of << parameters.env-name-path >>:"
-        cat << parameters.env-name-path >>
-        if [[ -f << parameters.env-name-path >> ]]; then
-          DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
-        else
-          DEV_ENV_NAME=<< parameters.e2e-env-name >>
-        fi
+        if [ -f << parameters.env-name-path >> ] && [ "$(cat << parameters.env-name-path >> )" != "null" ]; then
+              DEV_ENV_NAME=$(cat << parameters.env-name-path >> )
+          else
+              DEV_ENV_NAME=<< parameters.e2e-env-name >>
+          fi
         # Read components into an array directly from the command output
         components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
         # Gather summary state of all pods in the namespace

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -28,10 +28,12 @@ steps:
       environment:
         LOG_DIR: &log_dir  /tmp/pod-logs-{{ .values.e2e_env_name }}
       command: |
-        if [ -f workspace/env_name ] && [ "$(cat workspace/env_name)" != "null" ]; then
-            DEV_ENV_NAME=$(cat workspace/env_name)
+        echo "Contents of << parameters.env-name-path >>:"
+        cat << parameters.env-name-path >>
+        if [[ -f << parameters.env-name-path >> ]]; then
+          DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
         else
-            DEV_ENV_NAME=<< parameters.e2e-env-name >>
+          DEV_ENV_NAME=<< parameters.e2e-env-name >>
         fi
         # Gather summary state of all pods in the namespace
         echo "Gathering Kubernetes state before run for env $DEV_ENV_NAME"
@@ -68,7 +70,9 @@ steps:
         mkdir "${LOG_DIR:?}"
         capture_logs
 
-  - run: |
+  - run:
+     name: Wait for smoke-tests job to complete
+     command: |
       # The waiter job keeps looping through to check if the smoke-tests job has been completed
       while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CIRCLE_TOKEN"| jq -r '.items[]|select(.name == "vfcommon/run-smoke-tests")|.status' | grep -c "running") -gt 0 ]]
         do
@@ -80,8 +84,10 @@ steps:
       environment:
         LOG_DIR: *log_dir
       command: |
-        if [ -f workspace/env_name ] && [ "$(cat workspace/env_name)" != "null" ]; then
-          DEV_ENV_NAME=$(cat workspace/env_name)
+        echo "Contents of << parameters.env-name-path >>:"
+        cat << parameters.env-name-path >>
+        if [[ -f << parameters.env-name-path >> ]]; then
+          DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
         else
           DEV_ENV_NAME=<< parameters.e2e-env-name >>
         fi

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -30,7 +30,8 @@ steps:
         COMPONENT_LOG_DIR: &component_log_dir component-logs
         KUBE_STATE_DIR: &kube_state_dir kubernetes-state
       command: |
-        mkdir -p "${LOG_DIR:?}/{${COMPONENT_LOG_DIR:?},${KUBE_STATE_DIR:?}}"
+        mkdir -p "${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}"
+        mkdir -p "${LOG_DIR:?}/${KUBE_STATE_DIR:?}"
   - run:
       name: Gather Kubernetes state before run
       environment:
@@ -46,7 +47,7 @@ steps:
         fi
         # Gather summary state of all pods in the namespace
         echo "Gathering Kubernetes state before run for env $DEV_ENV_NAME"
-        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR}/pods-summary-state-before-run.log"
+        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/pods-summary-state-before-run.log"
   - run:
       name: Gather Logs
       environment:

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -15,12 +15,7 @@ parameters:
       default: "/home/circleci/voiceflow/env_name.txt"
 steps:
   - install-vfcli:
-      init-cluster: << parameters.cluster >>
-  - run:
-      name: Install stern
-      command: |
-        curl -sSL https://raw.githubusercontent.com/upciti/wakemeops/main/assets/install_repository | sudo bash
-        sudo apt install stern
+      init-cluster: << parameters.cluster >> 
   - restore_cache:
       key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   - run:
@@ -68,13 +63,13 @@ steps:
             for ((i = 0; i < ${#components[@]} - 1; i++)); do
                 component=${components[$i]}
                 echo "Capturing logs for component $component"
-                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" --since 1m &
+                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" --since 5m &
             done
             # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
             # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
             last_component=${components[${#components[@]}-1]}
             echo "Capturing logs for last component $last_component"
-            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log" --since 1m
+            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log" --since 5m
         }
         capture_logs
 

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -28,7 +28,7 @@ steps:
       environment:
         LOG_DIR: &log_dir  /tmp/logs-<< parameters.e2e-env-name >>
         COMPONENT_LOG_DIR: &component_log_dir component-logs
-        KUBE_STATE_DIR: &kube_state_dir kubernetes-state"
+        KUBE_STATE_DIR: &kube_state_dir kubernetes-state
       command: |
         mkdir -p "${LOG_DIR:?}/{${component-logs:?},${kubernetes-state:?}}"
   - run:

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -1,5 +1,4 @@
 description: Prepare an existing environment for e2e tests
-executor: default-executor
 
 parameters:
     cluster:
@@ -13,6 +12,11 @@ parameters:
       type: string
       description: Path to the env_name file
       default: "/home/circleci/voiceflow/env_name.txt"
+    executor:
+     description: Executor to run the command on
+     type: executor
+     default: default-executor
+executor: << parameters.executor >>
 steps:
   - install-vfcli:
       init-cluster: << parameters.cluster >>

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -24,9 +24,18 @@ steps:
   - restore_cache:
       key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   - run:
+    name: Create directories
+    environment:
+      LOG_DIR: &log_dir  /tmp/logs-<< parameters.e2e-env-name >>
+      COMPONENT_LOG_DIR: &component_log_dir component-logs
+      KUBE_STATE_DIR: &kube_state_dir kubernetes-state"
+    command: |
+      mkdir -p "${LOG_DIR:?}/{${component-logs:?},${kubernetes-state:?}}"
+  - run:
       name: Gather Kubernetes state before run
       environment:
-        LOG_DIR: &log_dir  /tmp/pod-logs-{{ .values.e2e_env_name }}
+        LOG_DIR: *log_dir
+        KUBE_STATE_DIR: *kube_state_dir
       command: |
         echo "Contents of << parameters.env-name-path >>:"
         cat << parameters.env-name-path >>
@@ -37,11 +46,12 @@ steps:
         fi
         # Gather summary state of all pods in the namespace
         echo "Gathering Kubernetes state before run for env $DEV_ENV_NAME"
-        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/pods-summary-state-before-run.log"
+        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR}/pods-summary-state-before-run.log"
   - run:
       name: Gather Logs
       environment:
         LOG_DIR:  *log_dir
+        COMPONENT_LOG_DIR: *component_log_dir
       background: true
       command: |
         function capture_logs() {
@@ -59,15 +69,14 @@ steps:
             for ((i = 0; i < ${#components[@]} - 1; i++)); do
                 component=${components[$i]}
                 echo "Capturing logs for component $component"
-                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/$component.log" &
+                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" &
             done
             # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
             # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
             last_component=${components[${#components[@]}-1]}
             echo "Capturing logs for last component $last_component"
-            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/$last_component.log"
+            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>""${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log"
         }
-        mkdir "${LOG_DIR:?}"
         capture_logs
 
   - run:
@@ -83,6 +92,7 @@ steps:
       name: Gather Kubernetes state after run
       environment:
         LOG_DIR: *log_dir
+        KUBE_STATE_DIR: *kube_state_dir
       command: |
         echo "Contents of << parameters.env-name-path >>:"
         cat << parameters.env-name-path >>
@@ -104,7 +114,7 @@ steps:
          # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
          # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
          last_component=${components[${#components[@]}-1]}
-         kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${last_component}-k8-state.log"
+         kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${last_component}-k8-state.log"
 
   - store_artifacts:
       name: Store Logs

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -30,7 +30,7 @@ steps:
         COMPONENT_LOG_DIR: &component_log_dir component-logs
         KUBE_STATE_DIR: &kube_state_dir kubernetes-state
       command: |
-        mkdir -p "${LOG_DIR:?}/{${component-logs:?},${kubernetes-state:?}}"
+        mkdir -p "${LOG_DIR:?}/{${COMPONENT_LOG_DIR:?},${KUBE_STATE_DIR:?}}"
   - run:
       name: Gather Kubernetes state before run
       environment:

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -1,0 +1,73 @@
+description: Prepare an existing environment for e2e tests
+executor: default-executor
+
+parameters:
+    cluster:
+      type: string
+      description: Name of the cluster in which the environment exists
+      default: "cm4-vf-dev-br-2-0-p1"
+    e2e-env-name:
+      type: string
+      description: Name of the environment to collect logs from
+    env-name-path:
+      type: string
+      description: Path to the env_name file
+      default: "/home/circleci/voiceflow/env_name.txt"
+steps:
+  - vfcommon/install-vfcli:
+      init-cluster: << parameters.cluster >>
+  - run:
+      name: Install stern
+      command: |
+        curl -sSL https://raw.githubusercontent.com/upciti/wakemeops/main/assets/install_repository | sudo bash
+        sudo apt install stern
+  - restore_cache:
+      key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+  - run:
+      name: Gather Logs
+      environment:
+        ENV_NAME: {{ .values.e2e_env_name }}
+        LOG_DIR: &log_dir /tmp/pod-logs-{{ .values.e2e_env_name }}
+      background: true
+      command: |
+        function capture_logs() {
+            echo "Contents of << parameters.env-name-path >>:"
+              cat << parameters.env-name-path >>
+            if [[ -f << parameters.env-name-path >> ]]; then
+                DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
+            else
+                DEV_ENV_NAME=<< parameters.e2e-env-name >>
+            fi
+            echo "Capturing logs for environment $DEV_ENV_NAME"
+            # Read components into an array directly from the command output
+            components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
+            # Iterate over the first n-1 components.Process log collection in parallel as background processes
+            for ((i = 0; i < ${#components[@]} - 1; i++)); do
+                component=${components[$i]}
+                echo "Capturing logs for component $component"
+                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/$component.log" &
+            done
+            # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
+            # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
+            last_component=${components[${#components[@]}-1]}
+            echo "Capturing logs for last component $last_component"
+            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/$last_component.log"
+        }
+        mkdir "${LOG_DIR:?}"
+        capture_logs
+
+  - run: |
+      # The waiter job keeps looping through to check if the smoke-tests job has been completed
+      while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CIRCLE_TOKEN"| jq -r '.items[]|select(.name == "vfcommon/run-smoke-tests")|.status' | grep -c "running") -gt 0 ]]
+        do
+          sleep 5
+        done
+  - run: echo "All required jobs have now completed"
+  - store_artifacts:
+      name: Store Logs
+      path: *log_dir
+      destination: logs
+  - store_artifacts:
+      name: Store Cluster Info
+      path: /tmp/cluster-info
+      destination: cluster-info

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -68,13 +68,13 @@ steps:
             for ((i = 0; i < ${#components[@]} - 1; i++)); do
                 component=${components[$i]}
                 echo "Capturing logs for component $component"
-                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" &
+                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" --since 1m &
             done
             # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
             # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
             last_component=${components[${#components[@]}-1]}
             echo "Capturing logs for last component $last_component"
-            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log"
+            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$last_component.log" --since 1m
         }
         capture_logs
 
@@ -101,12 +101,12 @@ steps:
         # Read components into an array directly from the command output
         components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
         # Gather summary state of all pods in the namespace
-        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/pods-summary-state-after-run.log"
+        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/pods-summary-state-after-run.log"
         # Gather detailed state of all pods in the namespace
         for ((i = 0; i < ${#components[@]} - 1; i++)); do
             component=${components[$i]}
             echo "Capturing logs for component $component"
-            kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${component}-k8-state.log" &
+            kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${component}-k8-state.log" &
          done
          # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
          # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
@@ -117,7 +117,3 @@ steps:
       name: Store Logs
       path: *log_dir
       destination: logs
-  - store_artifacts:
-      name: Store Cluster Info
-      path: /tmp/cluster-info
-      destination: cluster-info

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -14,7 +14,7 @@ parameters:
       description: Path to the env_name file
       default: "/home/circleci/voiceflow/env_name.txt"
 steps:
-  - vfcommon/install-vfcli:
+  - install-vfcli:
       init-cluster: << parameters.cluster >>
   - run:
       name: Install stern

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -24,9 +24,22 @@ steps:
   - restore_cache:
       key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   - run:
+      name: Gather Kubernetes state before run
+      environment:
+        LOG_DIR: &log_dir  /tmp/pod-logs-{{ .values.e2e_env_name }}
+      command: |
+        if [ -f workspace/env_name ] && [ "$(cat workspace/env_name)" != "null" ]; then
+            DEV_ENV_NAME=$(cat workspace/env_name)
+        else
+            DEV_ENV_NAME=<< parameters.e2e-env-name >>
+        fi
+        # Gather summary state of all pods in the namespace
+        echo "Gathering Kubernetes state before run for env $DEV_ENV_NAME"
+        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/pods-summary-state-before-run.log"
+  - run:
       name: Gather Logs
       environment:
-        LOG_DIR: &log_dir /tmp/pod-logs-{{ .values.e2e_env_name }}
+        LOG_DIR:  *log_dir
       background: true
       command: |
         function capture_logs() {
@@ -62,6 +75,31 @@ steps:
           sleep 5
         done
   - run: echo "All required jobs have now completed"
+  - run:
+      name: Gather Kubernetes state after run
+      environment:
+        LOG_DIR: *log_dir
+      command: |
+        if [ -f workspace/env_name ] && [ "$(cat workspace/env_name)" != "null" ]; then
+          DEV_ENV_NAME=$(cat workspace/env_name)
+        else
+          DEV_ENV_NAME=<< parameters.e2e-env-name >>
+        fi
+        # Read components into an array directly from the command output
+        components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
+        # Gather summary state of all pods in the namespace
+        kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/pods-summary-state-after-run.log"
+        # Gather detailed state of all pods in the namespace
+        for ((i = 0; i < ${#components[@]} - 1; i++)); do
+            component=${components[$i]}
+            echo "Capturing logs for component $component"
+            kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${component}-k8-state.log" &
+         done
+         # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
+         # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
+         last_component=${components[${#components[@]}-1]}
+         kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${last_component}-k8-state.log"
+
   - store_artifacts:
       name: Store Logs
       path: *log_dir


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* [IN-1101](https://linear.app/voiceflow/issue/IN-1101/improve-logs-in-our-cicd-system)

### Successful run 
* https://app.circleci.com/pipelines/gh/voiceflow/general-runtime/16323/workflows/7dc9898c-138b-4b7e-a71d-b2e206b4c216
### Brief description. What is this change?
* The change allows us to 
  * Capture component logs during a smoke test run 
     * Logs are `tailed` for the duration of the smoke test run allowing us to preserve logs from initial pod instance if a 
     pod restart occurs
   * Capture summary pod state for all pods before smoke test run 
   * Capture summary pod state for all pods after smoke test run 
   * Capture detailed pod state for each pod after smoke test run 

### Important technics used (details to be included in notion page as well) 
*  Use a separate job that runs in parallel to smoke tests job so that we can capture the 8 parallel smoke test run logs as 
    an aggregate  
* Use stern for log tailing instead of normal `kubectl` to utilize stern's reconnection mechanism.If a pod restarts, kubectl terminates the connection but stern can resume log collection on the new pod instance 
* Use file appending with >> so that the tailed logs are written to file as they are streamed.This helps so that we dont corrupt file descriptors when the log collection job is cancelled.All the appended content is written and committed to the file and there will be no data loss on abrupt process termination.
* Use a  circleci background step for the log capture itself.This runs parallel to the other steps in the job, is non blocking and will terminate when there are no more steps running in the job 
* In the background step that captures logs, capture all component logs.
   * Log capture is a blocking call, so if we capture for one component, we cant capture for the other components 
   * To enable capture of multiple component logs, spawn a separate background process for n-1 components using the & at the end of the command
   * We cant make all the component log collection processes background as the circleci step will terminate and have no foreground process to attach to
   * We make the last component process run in a blocking way without & at the end 
* The log collection step itself runs parallel to the rest of the steps, allowing the subsequent step after it to be executed immediately without waiting.The next step uses the waiter technic to poll circleci api so that log collection job can stop executing and start cleanup tasks when smoke test job finishes 
* kubernetes state does not need to be tailed, so we can capture the detailed state last after smoke test run
   * kubectl is also blocking, this stops us from capturing multiple components using a for loop in one go
   * Use the same technic as described above to run n-1 components kubectl commands using non-blocking processes
   * Only run one of the kubectl commands for the last component as a foreground process
*  When stern was run locally, we can see that the background processes linger after parent bash script that called them is terminated
    * This was a concern that we could leave dangling processes on circleci but a test was done and it was observed that circleci cleans up and removes the background processes that are child processes of a terminated shell/step when a step finished  execution    

### Related PR's 
* https://github.com/voiceflow/general-runtime/pull/838
* https://github.com/voiceflow/infrastructure/pull/685

### Checklist

- [x] Logs collect on a successful run 
- [x] Logs collect on a failed run 
    