### PR TITLE
fix: resolve why k8 logs are missing:IN-1219

### DIFF
--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -119,7 +119,7 @@ steps:
         LOG_DIR: *log_dir
       command: |
         tar -czf /tmp/logs.tar.gz ${LOG_DIR:?}
-    
+
   - store_artifacts:
       name: Store compressed logs
       path: /tmp/logs.tar.gz

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -113,18 +113,18 @@ steps:
         #  last_component=${components[${#components[@]}-1]}
         #  kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${last_component}-k8-state.log"
 
+  - store_artifacts:
+      name: Store uncompressed logs
+      path: *log_dir
+      destination: logs
+
   - run:
       name: Compress logs
       environment:
         LOG_DIR: *log_dir
       command: |
-        mkdir -p /tmp/logs/compressed
-        cp -r ${LOG_DIR:?} /tmp/logs/compressed
-        tar -czf /tmp/logs.tar.gz /tmp/logs/compressed
-  - store_artifacts:
-      name: Store uncompressed logs
-      path: *log_dir
-      destination: logs
+        tar -czf /tmp/logs.tar.gz ${LOG_DIR:?}
+        
   - store_artifacts:
       name: Store compressed logs
       path: /tmp/logs.tar.gz

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -108,11 +108,6 @@ steps:
             kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${component}-k8-state.log" &
          done
          wait
-         # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
-         # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
-        #  last_component=${components[${#components[@]}-1]}
-        #  kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${last_component}-k8-state.log"
-
   - store_artifacts:
       name: Store uncompressed logs
       path: *log_dir
@@ -124,7 +119,7 @@ steps:
         LOG_DIR: *log_dir
       command: |
         tar -czf /tmp/logs.tar.gz ${LOG_DIR:?}
-        
+    
   - store_artifacts:
       name: Store compressed logs
       path: /tmp/logs.tar.gz

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -102,15 +102,16 @@ steps:
         # Gather summary state of all pods in the namespace
         kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/pods-summary-state-after-run.log"
         # Gather detailed state of all pods in the namespace
-        for ((i = 0; i < ${#components[@]} - 1; i++)); do
+        for ((i = 0; i < ${#components[@]}; i++)); do
             component=${components[$i]}
             echo "Capturing logs for component $component"
             kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${component}-k8-state.log" &
          done
+         wait
          # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
          # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
-         last_component=${components[${#components[@]}-1]}
-         kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${last_component}-k8-state.log"
+        #  last_component=${components[${#components[@]}-1]}
+        #  kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${last_component}-k8-state.log"
 
   - run:
       name: Compress logs

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -101,7 +101,7 @@ steps:
         components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
         # Gather summary state of all pods in the namespace
         kubectl get pods -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/pods-summary-state-after-run.log"
-        # Gather detailed state of all pods in the namespace
+        # Gather detailed state of all pods in the namespace.
         for ((i = 0; i < ${#components[@]}; i++)); do
             component=${components[$i]}
             echo "Capturing logs for component $component"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* https://linear.app/voiceflow/issue/IN-1219/investigate-why-e2e-k8s-logs-are-missing-for-some-pods

### Brief description. What is this change?
* Some component logs are not showing  
  * Not even getting collected
  * For some that are collected, they are not in the compressed folder 
* The compressed logs have too many nested level folders

### Fix
* Handle race condition caused by background processes being cut off by the blocking process if blocking process finishes quicker 
* Use the internal waiting mechanism `wait` that bash provides that can finish when all processes are done instead of waiting on our own blocking mechanism that waits only for last job
* This is needed only for K8 state collection and not stern component logs 
  * This is because stern logs process is long running and wont need special waiting idioms 
* When unzipping logs, there were too many folders to navigate 
``` 
% find . -type d
.
./tmp
./tmp/logs
./tmp/logs/compressed
./tmp/logs/compressed/logs-e2e-dc35c8e
./tmp/logs/compressed/logs-e2e-dc35c8e/kubernetes-state
./tmp/logs/compressed/logs-e2e-dc35c8e/component-logs
```
* A fix has been made to reduce the number of folders to open 
```
./tmp
./tmp/logs-e2e-dc35c8e
./tmp/logs-e2e-dc35c8e/kubernetes-state
./tmp/logs-e2e-dc35c8e/component-logs
```

### Related PR's 
* https://github.com/voiceflow/general-runtime/pull/845

### Checklist

- [x] Tested