### PR TITLE
fix: added a new command to free env (IN-1241)

### DIFF
--- a/src/commands/vfcli/vfcli-delete-or-release-env.yml
+++ b/src/commands/vfcli/vfcli-delete-or-release-env.yml
@@ -38,6 +38,7 @@ steps:
             vfcli pool release-env --env-name "$env_name"
             vfcli env resume "$env_name" --interactive false
             vfcli track attach --branch master --components all --name "$env_name" --interactive false
+            vfcli pool free-env --env-name "$env_name"
           else
             echo "Kick-starting the deletion of the environment."
             vfcli env delete --name "<< parameters.env-name >>" --interactive false


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-1241**

### Brief description. What is this change?

Added command to free up environment after resetting its track

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test