### PR TITLE
fix: test smaller yarn cache (ENG-170)

### DIFF
--- a/src/commands/yarn/install_node_modules.yml
+++ b/src/commands/yarn/install_node_modules.yml
@@ -60,7 +60,7 @@ steps:
   - run:
       name: Install pnpm package manager
       command: |
-        corepack enable
+        sudo corepack enable
         corepack prepare pnpm@latest-9 --activate
         pnpm config set store-dir .pnpm-store
   - run:

--- a/src/commands/yarn/install_node_modules.yml
+++ b/src/commands/yarn/install_node_modules.yml
@@ -6,7 +6,7 @@ parameters:
   working_directory:
     description: Directory containing package.json
     type: string
-    default: './'
+    default: "./"
   step_name:
     description: Name of the step
     type: string
@@ -14,11 +14,11 @@ parameters:
   yarn_lock_restore_cache_directory:
     description: Cache directory for yarn.lock file
     type: string
-    default: './'
+    default: "./"
   cache_prefix:
     description: Cache prefix
     type: string
-    default: ''
+    default: ""
   avoid_post_install_scripts:
     description: Skip running post install scripts
     type: boolean
@@ -53,62 +53,22 @@ parameters:
     default: "168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-build-image:v1"
 steps:
   - authenticate_npm
-  - when:
-      condition:
-        equal:
-          - python
-          - "<< parameters.language >>"
-      steps:
-        - authenticate_poetry:
-            working_directory: << parameters.working_directory >>
-        - vf_python_restore_cache:
-            cache_prefix: << parameters.cache_prefix >>
-        - run:
-            name: Install Python dependencies
-            command: |
-              poetry install
-              source .venv/bin/activate
-              # Activates the virtual environment for the current job
-              echo "source .venv/bin/activate" >> $BASH_ENV
-  - vf_restore_cache:
-      yarn_lock_restore_cache_directory: << parameters.yarn_lock_restore_cache_directory >>
-      cache_prefix: << parameters.cache_prefix >>
-  - when:
-      condition: << parameters.avoid_post_install_scripts >>
-      steps:
-        - yarn_command:
-            working_directory: << parameters.working_directory >>
-            run_in_background: << parameters.run_in_background >>
-            request_remote_docker: << parameters.request_remote_docker >>
-            container_folder_to_copy: << parameters.container_folder_to_copy >>
-            run_in_container: << parameters.run_in_container >>
-            container_image: << parameters.container_image >>
-            step_name: << parameters.step_name >>
-            wait: << parameters.wait >>
-            yarn_command: yarn install --immutable << parameters.install_args >> 2>&1 | tee output.file
-  - unless:
-      condition: << parameters.avoid_post_install_scripts >>
-      steps:
-        - yarn_command:
-            working_directory: << parameters.working_directory >>
-            run_in_background: << parameters.run_in_background >>
-            request_remote_docker: << parameters.request_remote_docker >>
-            container_folder_to_copy: << parameters.container_folder_to_copy >>
-            run_in_container: << parameters.run_in_container >>
-            container_image: << parameters.container_image >>
-            step_name: << parameters.step_name >>
-            wait: << parameters.wait >>
-            yarn_command: yarn install --immutable  << parameters.install_args >>
-
-  - when:
-      condition:
-        equal:
-          - python
-          - "<< parameters.language >>"
-      steps:
-        - vf_python_save_cache:
-            cache_prefix: << parameters.cache_prefix >>
-
-  - vf_save_cache: # special step to save the dependency cache
-      working_directory: << parameters.working_directory >>
-      cache_prefix: << parameters.cache_prefix >>
+  - restore_cache:
+      name: Restore pnpm Package Cache
+      keys:
+        - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+  - run:
+      name: Install pnpm package manager
+      command: |
+        corepack enable
+        corepack prepare pnpm@latest-9 --activate
+        pnpm config set store-dir .pnpm-store
+  - run:
+      name: Install Dependencies
+      command: |
+        pnpm install
+  - save_cache:
+      name: Save pnpm Package Cache
+      key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+      paths:
+        - .pnpm-store

--- a/src/commands/yarn/vf_save_cache.yml
+++ b/src/commands/yarn/vf_save_cache.yml
@@ -2,16 +2,13 @@ parameters:
   working_directory:
     description: Directory containing package.json
     type: string
-    default: './'
+    default: "./"
   cache_prefix:
     description: Cache prefix
     type: string
-    default: ''
+    default: ""
 steps:
   - save_cache: # special step to save the dependency cache
       key: node-module-cache-<< parameters.cache_prefix >>-{{ .Environment.CACHE_VERSION }}-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
       paths:
         - << parameters.working_directory >>/.yarn/cache
-        - << parameters.working_directory >>/.yarn/install-state.gz
-        - << parameters.working_directory >>/node_modules
-        - ~/.cache/Cypress


### PR DESCRIPTION
Test if can get away without caching all of node_modules and that the overall speed is as good as with it.

Historically the `link` step in yarn took way too long.