### PR TITLE
feat: add kubernetes events to logs:IN-1271

### DIFF
--- a/src/executors/node/node-executor-node-20.yml
+++ b/src/executors/node/node-executor-node-20.yml
@@ -4,7 +4,7 @@ parameters:
     type: string
     default: medium+
   default_node_memory:
-    description: Default node memory
+    description: Default node memory.
     type: string
     default: '4096'
   tag:

--- a/src/executors/node/node-executor-node-20.yml
+++ b/src/executors/node/node-executor-node-20.yml
@@ -9,7 +9,7 @@ parameters:
     default: '4096'
   tag:
     type: string
-    default: v4
+    default: 20.11.1-vf-4
 working_directory: ~/voiceflow
 docker:
   - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:<< parameters.tag >>

--- a/src/executors/node/node-executor-node-20.yml
+++ b/src/executors/node/node-executor-node-20.yml
@@ -9,7 +9,7 @@ parameters:
     default: '4096'
   tag:
     type: string
-    default: v3
+    default: v4
 working_directory: ~/voiceflow
 docker:
   - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:<< parameters.tag >>

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -122,7 +122,24 @@ steps:
         # Gather all events in the namespace except those from external-secrets and secret-store
         # These doppler sync events are very verbose and are not relevant to the e2e tests
         # Kubernetes events have a ttl of 1 hr.The way we have implemented the events capture allows us to view them in an ordered way that allows us to correlate them with the e2e test run
-        kubectl get event -n "${DEV_ENV_NAME:?}" --field-selector 'source!=external-secrets,source!=secret-store' >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/k8-events.log"
+        kubectl get events -n "${DEV_ENV_NAME:?}" -o json | jq -r  '
+          ["LAST-SEEN", "NAME", "REASON", "SOURCE_COMPONENT", "TYPE", "MESSAGE"],
+            (.items[]
+               | select(.source.component != "external-secrets")
+               | select(.source.component != "secret-store")
+              | [
+                .lastTimestamp,
+                .metadata.name,
+                (.reason // "-"),
+                (.source.component // "-"),
+                (.type // "-"),
+                (.message // "-")
+              ]
+            )
+            | map(. | tostring | gsub("\n"; " "))
+            | @tsv
+          ' | column -t -s $'\t' >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/k8-events.log"
+
 
   - store_artifacts:
       name: Store uncompressed logs

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -122,7 +122,7 @@ steps:
         # Gather all events in the namespace except those from external-secrets and secret-store
         # These doppler sync events are very verbose and are not relevant to the e2e tests
         # Kubernetes events have a ttl of 1 hr, return all relevant namespace events.Use jq to return actual timestamp of event so it can be corelated to service logs.
-        # The entries are then manipulated to return only the required fields in readable format  
+        # The entries are then manipulated to return only the required fields in readable format
         kubectl get events -n "${DEV_ENV_NAME:?}" -o json | jq -r  '
           ["LAST-SEEN", "NAME", "REASON", "SOURCE_COMPONENT", "TYPE", "MESSAGE"],
             (.items[]

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -108,6 +108,22 @@ steps:
             kubectl describe pod $component -n $DEV_ENV_NAME >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/${component}-k8-state.log" &
          done
          wait
+  - run:
+      name: Gather Kubernetes events 
+      environment:
+        LOG_DIR: *log_dir
+        KUBE_STATE_DIR: *kube_state_dir
+      command: |       
+        if [ -f << parameters.env-name-path >> ] && [ "$(cat << parameters.env-name-path >> )" != "null" ]; then
+            DEV_ENV_NAME=$(cat << parameters.env-name-path >> )
+        else
+            DEV_ENV_NAME=<< parameters.e2e-env-name >>
+        fi
+        # Gather all events in the namespace except those from external-secrets and secret-store
+        # These doppler sync events are very verbose and are not relevant to the e2e tests
+        # Kubernetes events have a ttl of 1 hr.The way we have implemented the events capture allows us to view them in an ordered way that allows us to correlate them with the e2e test run
+        kubectl get event -n "${DEV_ENV_NAME:?}" --field-selector 'source!=external-secrets,source!=secret-store' >> "${LOG_DIR:?}/${KUBE_STATE_DIR:?}/k8-events.log"
+
   - store_artifacts:
       name: Store uncompressed logs
       path: *log_dir

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -109,11 +109,11 @@ steps:
          done
          wait
   - run:
-      name: Gather Kubernetes events 
+      name: Gather Kubernetes events
       environment:
         LOG_DIR: *log_dir
         KUBE_STATE_DIR: *kube_state_dir
-      command: |       
+      command: |
         if [ -f << parameters.env-name-path >> ] && [ "$(cat << parameters.env-name-path >> )" != "null" ]; then
             DEV_ENV_NAME=$(cat << parameters.env-name-path >> )
         else

--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -121,7 +121,8 @@ steps:
         fi
         # Gather all events in the namespace except those from external-secrets and secret-store
         # These doppler sync events are very verbose and are not relevant to the e2e tests
-        # Kubernetes events have a ttl of 1 hr.The way we have implemented the events capture allows us to view them in an ordered way that allows us to correlate them with the e2e test run
+        # Kubernetes events have a ttl of 1 hr, return all relevant namespace events.Use jq to return actual timestamp of event so it can be corelated to service logs.
+        # The entries are then manipulated to return only the required fields in readable format  
         kubectl get events -n "${DEV_ENV_NAME:?}" -o json | jq -r  '
           ["LAST-SEEN", "NAME", "REASON", "SOURCE_COMPONENT", "TYPE", "MESSAGE"],
             (.items[]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [ticket](https://linear.app/voiceflow/issue/IN-1271/add-events-to-e2e-logs) 


### Brief description. What is this change?
* Include kubernetes events in the gathered logs 

### Considerations 
  * Gather all events in the namespace except those from external-secrets and secret-store
  * These doppler sync events are very verbose and are not relevant to the e2e tests
  *  Kubernetes events have a ttl of 1 hr, return all relevant namespace events.Use jq to return actual timestamp of event so it can be corelated to service logs.
  * The entries are then manipulated to return only the required fields in readable format
  * This clean format is easier to read and useful in debugging, we dont want to return the entire JSON entry that represents an event as it has lots of unnecessary information that can slow down troubleshooting  



- [x] Tested in a PR 

* https://github.com/voiceflow/general-runtime/pull/862
* [Successful run ](https://app.circleci.com/pipelines/github/voiceflow/general-runtime/16798/workflows/afd02572-84a8-4035-b945-f3d2b667b2d6/jobs/39411/artifacts)
  * file generated -> [logs/kubernetes-state/k8-events.log](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/artifacts/3619b714-0a5f-4fe8-9419-43968f4ec248/7db82e0b-31a5-42af-9e39-6d8268c07ada/0/logs/kubernetes-state/k8-events.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQVFQINEOBWIF4ROB%2F20240705%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240705T050538Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEP3%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCIAZOaItj5azK%2BNJbvIaMLsc9PuokUV%2F3WU7YST%2BXkg5OAiBcwZoFXtLPj8sZ7dLKlpj6Jcor15mOmZpJzPsSBHMuiyq0Agi2%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAMaDDA0NTQ2NjgwNjU1NiIMXBWTkENxzMh1zRoBKogCoLuIN1i1rXvGZ90dKGPrs%2B5hFK6nUC7PFLOgTFPJiCx82VRMrP7yV0AtjwRnwfcf1UHj4R%2BYVI8OCdAWt7j8piQgUc2Lo4cemkFPJbFjqf5Z0nd864srP6d8d5M2ilPWIzg2wzTx8zYCHIBKmp77e9ZgNv6IadJa%2BBMT5hv0meJ2jJsl%2Bxqozg6cx6CitqTZynNH%2BdaI2WeNFgQvJDFkeloZmvuuOZBvm4sa%2FMaweuSeM32qsiPLIRk%2Bw1wBa3I8LBrejICoLqCOk%2BlwGQ5FTFkVnhAWPskgpc9qStzZB81kYbdnELb5s%2BUf0Y9p2Qwqb066pm9juz6lso8Lbuo0bN2ol2XXc1M3MI36nbQGOp4BdGiKm1Wwdazv23gfwHqpslthtDtKuHvV79%2Buxj%2F9xQRMo7In%2Bk9%2FVnuPHZ2i61XAqfgNFHfqIwCAojbN8LpjP1QSEJWUVl4%2FoAXyLoCQE7VznkYqmynzszXXLRO3lY%2FWUZdCTSeTgJGs00Se5RRAbLNOjeGmuge%2FL0Y00oKC2xKCetNjN1wwLL%2FaJiKLixc2O8Lm00ZQvdgTp3M753Y%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=f69f0f5d91a4bfa3001cb212e1627b6900f99dc85c23f52208fd0c12e69d989e)