### PR TITLE
feat: notify in slack when smoke tests fail (DX-1921)

### DIFF
--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -93,4 +93,4 @@ steps:
             event: fail
             mentions: "@eng_dx"
             template: basic_fail_1
-            branch_pattern: /.*/
+            branch_pattern: trying

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -29,6 +29,9 @@ parameters:
     type: string
     description: Path to the env_name file
     default: "/home/circleci/voiceflow/env_name.txt"
+  notify_on_fail:
+      type: boolean
+      default: true
 steps:
   - clone_repo:
       github_repo_name: automated-testing
@@ -82,4 +85,11 @@ steps:
   - store_artifacts:
       path: apps/smoke-test-runner/cypress/logs
       destination: logs
-
+  - when:
+      condition: << parameters.notify_on_fail >>
+      steps:
+        - notify_slack:
+            channel: test_failures
+            event: fail
+            mentions: "@eng_dx"
+            template: basic_fail_1

--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -93,3 +93,4 @@ steps:
             event: fail
             mentions: "@eng_dx"
             template: basic_fail_1
+            branch_pattern: /.*/


### PR DESCRIPTION
Add logic to the `run-smoke-tests` job that posts failures to `#test_failures` using the `notify_slack` command