### PR TITLE
feat: New command and job to reset database and free pool

### DIFF
--- a/src/commands/vfcli/vfcli-resetdb-free-env.yml
+++ b/src/commands/vfcli/vfcli-resetdb-free-env.yml
@@ -1,0 +1,18 @@
+description: Uses vfcli to reset database and free an environment back into the pool
+
+parameters:
+  env-name:
+    type: string
+    description: Name of the environment to create
+steps:
+  - run:
+      name: Release or Delete Env
+      when: << parameters.when >>
+      command: |
+        env_name="<< parameters.env-name >>"
+        echo "Releasing the environment..... $env_name"
+        vfcli env resume "$env_name" --interactive false
+        vfcli track attach --branch master --components all --name "$env_name" --interactive false --no-circleci
+        vfcli env database reset --name "$env_name"
+        vfcli component restart --name "$env_name" --wait
+        vfcli pool free-env --env-name "$env_name"

--- a/src/commands/vfcli/vfcli-resetdb-free-env.yml
+++ b/src/commands/vfcli/vfcli-resetdb-free-env.yml
@@ -6,8 +6,7 @@ parameters:
     description: Name of the environment to create
 steps:
   - run:
-      name: Release or Delete Env
-      when: << parameters.when >>
+      name: Reset Database and Free Environment
       command: |
         env_name="<< parameters.env-name >>"
         echo "Releasing the environment..... $env_name"

--- a/src/jobs/e2e/resetdb-free-env.yml
+++ b/src/jobs/e2e/resetdb-free-env.yml
@@ -1,0 +1,17 @@
+
+description: Release an environment from use by the e2e tests
+executor: default-executor
+
+parameters:
+  env-name:
+    type: string
+    description: Name of the environment to release
+  cluster:
+    type: string
+    description: Name of the cluster in which the environment exists
+    default: "cm4-vf-dev-br-2-0-p1"
+steps:
+  - install-vfcli:
+      init-cluster: << parameters.cluster >>
+  - vfcli-resetdb-free-env:
+      env-name: << parameters.env-name >>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-1321**

### Brief description. What is this change?

Added new command and job to reset database and free an env back into the pool

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test