### PR TITLE
feat: refactor database cli push to use buildx

### DIFF
--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -10,6 +10,30 @@ parameters:
   image_repo:
     description: The container image repository
     type: string
+  dockerfile:
+    description: Name of the Dockerfile to build
+    type: string
+    default: Dockerfile
+  extra_build_args:
+    description: Arguments to pass while building the docker image
+    type: string
+    default: ''
+  enable_load:
+    description: Load image into local docker
+    type: boolean
+    default: false
+  enable_cache_to:
+    description: use --cache-to flag to push cache artifact to remote registry
+    type: boolean
+    default: false
+  build_context:
+    description: Path to the context for the docker build
+    type: string
+    default: '.'
+  force_execute:
+    description: force to update the build, if there is a change or not.
+    type: boolean
+    default: false
   bucket:
     description: The container image repository
     type: string
@@ -21,15 +45,83 @@ parameters:
     description: container image to run verdaccio
     type: string
     default: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-build-image:v1
+  local_registry:
+    description: Use a local proxy registry to publish alpha version of all libraries in monorepo (must have a /config/verdaccio/config.yaml file)
+    type: boolean
+    default: false
+  platform:
+    description: Platform to build the image
+    type: string
+    default: linux/amd64
+  enable_dlc:
+    description: enable docker layer cache
+    type: boolean
+    default: false
+  builder_name:
+    description: named builder for use with DLC
+    type: string
+    default: ""
+  enable_push:
+    description: push the image to the registry
+    type: boolean
+    default: true
+  request_remote_docker:
+    description: Add the option to request a new remote docker, set to false when you concat docker jobs
+    type: boolean
+    default: true
+  remote_docker_version:
+    description: Linux/amd64 allows for specific versions to be set, while linux/arm64 only allows for either default and edge
+    # https://circleci.com/docs/building-docker-images/#docker-version
+    type: string
+    default: "default"
+  package:
+    description: Monorepo package.
+    type: string
+    default: ""
+  package_folder:
+    description: Package folder to check
+    type: string
+    default: "packages"
+  kms_key:
+    description: KMS Key to sign the containers
+    type: string
+    default: "awskms:///2e64fa98-d1b0-491a-acf6-1f5fc6f94ecf"
+  inject_aws_credentials:
+    description: Inject AWS credentials into the build
+    type: boolean
+    default: false
+  check_track_exists:
+    description: checks if the track exists
+    type: boolean
+    default: true
 steps:
-  - when:
-      condition: << parameters.checkout >>
-      steps:
-        - checkout_clone # special step to check out source code to working directory
-  - check_track_exists:
-      component: << parameters.component >>
-  - attach_workspace:
-      at: ~/voiceflow
+  - update_track:
+      image_repo: "<< parameters.image_repo >>"
+      component: "<< parameters.component >>"
+      dockerfile: "<< parameters.dockerfile >>"
+      extra_build_args: << parameters.extra_build_args >>
+      enable_cache_to: "<< parameters.enable_cache_to >>"
+      build_context: "<< parameters.build_context >>"
+      checkout: "<< parameters.checkout >>"
+      request_remote_docker: "<< parameters.request_remote_docker >>"
+      remote_docker_version: "<< parameters.remote_docker_version >>"
+      bucket: "<< parameters.bucket >>"
+      check_track_exists: "<< parameters.check_track_exists >>"
+      local_registry: "<< parameters.local_registry >>"
+      force_execute: "<< parameters.force_execute >>"
+      package: "<< parameters.package >>"
+      package_folder: "<< parameters.package_folder >>"
+      image_tag: '<< parameters.semantic_version >>'
+      kms_key: "<< parameters.kms_key >>"
+      inject_aws_credentials: "<< parameters.inject_aws_credentials >>"
+      local_registry_container_image: "<< parameters.local_registry_container_image >>"
+      platform: "<< parameters.platform >>"
+      enable_dlc: "<< parameters.enable_dlc >>"
+      enable_load: "<< parameters.enable_load >>"
+      builder_name: "<< parameters.builder_name >>"
+      update_track_file: false
+      enable_push: "<< parameters.enable_push >>"
+  # The format of the track file for the database is different from the other tracks
   - run:
       name: Update Track
       environment:
@@ -37,9 +129,3 @@ steps:
         BUCKET: '<< parameters.bucket >>'
         COMPONENT: '<< parameters.component >>'
       command: <<include(scripts/track/update_database_track.sh)>>
-  - build_push_image:
-      checkout: false
-      image_repo: << parameters.image_repo >>
-      image_tag: '<< parameters.semantic_version >>'
-      sem_ver_override: '<< parameters.semantic_version >>'
-      local_registry_container_image: << parameters.local_registry_container_image >>

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -112,6 +112,7 @@ steps:
       package: "<< parameters.package >>"
       package_folder: "<< parameters.package_folder >>"
       image_tag: '<< parameters.semantic_version >>'
+      sem_ver_override: "<< parameters.semantic_version >>"
       kms_key: "<< parameters.kms_key >>"
       inject_aws_credentials: "<< parameters.inject_aws_credentials >>"
       local_registry_container_image: "<< parameters.local_registry_container_image >>"

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -63,6 +63,10 @@ parameters:
     description: The container image tag
     type: string
     default: ""
+  sem_ver_override:
+    description: Semantic release version of the package
+    type: string
+    default: ""
   kms_key:
     description: KMS Key to sign the containers
     type: string
@@ -153,4 +157,5 @@ steps:
         BUILDER_NAME: "<< parameters.builder_name >>"
         UPDATE_TRACK_FILE: << parameters.update_track_file >>
         ENABLE_PUSH: "<< parameters.enable_push >>"
+        SEM_VER_OVERRIDE: "<< parameters.sem_ver_override >>"
       command: <<include(scripts/track/update_track.sh)>>

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -95,6 +95,10 @@ parameters:
     description: Determines if the track file will be updated or not
     type: boolean
     default: true
+  enable_push:
+    description: push the image to the registry
+    type: boolean
+    default: true
 steps:
   - when:
       condition: << parameters.checkout >>
@@ -148,4 +152,5 @@ steps:
         PLATFORM: "<< parameters.platform >>"
         BUILDER_NAME: "<< parameters.builder_name >>"
         UPDATE_TRACK_FILE: << parameters.update_track_file >>
+        ENABLE_PUSH: "<< parameters.enable_push >>"
       command: <<include(scripts/track/update_track.sh)>>

--- a/src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml
+++ b/src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml
@@ -29,6 +29,7 @@ steps:
   - run:
       name: Check for free environment or Create environment
       command: |
+        force="<< parameters.force >>"
         # fetches a free environment from the pool if pool-type is provided
         # otherwise creates a new environment with the provided name
         # and stores the env name in the cache

--- a/src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml
+++ b/src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml
@@ -36,6 +36,8 @@ steps:
         if [[ -n "<< parameters.pool-type >>" ]]; then
           if [[ $force ]]; then
             echo "Force option is enabled... Proceeding with environment creation."
+            echo "null" > env_name.txt  # Write 'null' to indicate no environment was found
+            echo "create" > skip_create_env
           else
             result=$(vfcli pool get-free-env --pool-type "<< parameters.pool-type >>" --output json)
             if [[ -z $result ]] || [[ $(echo "$result" | jq 'keys | length') -eq 0 ]]; then

--- a/src/commands/vfcli/vfcli-delete-or-release-env.yml
+++ b/src/commands/vfcli/vfcli-delete-or-release-env.yml
@@ -16,6 +16,10 @@ parameters:
     type: string
     description: Path to the env_name file
     default: "/home/circleci/voiceflow/env_name.txt"
+  reset-db:
+    type: boolean
+    description: Whether to reset the database
+    default: false
 steps:
   - restore_cache:
       key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
@@ -36,6 +40,24 @@ steps:
           if [[ "$env_name" != "null" ]] && [[ -n "$env_name" ]]; then
             echo "Releasing the environment..... $env_name"
             vfcli pool release-env --env-name "$env_name"
+            if [[ << parameters.reset-db >> == true ]]; then
+              echo "Resetting the database for $env_name"
+              vfcli pool release-env --env-name "$env_name"
+              echo "Triggering pipeline with env-name parameter"
+              response=$(curl -s -o /dev/null -w "%{http_code}" \
+                --request POST \
+                --url "https://circleci.com/api/v2/project/gh/voiceflow/env-release-system/pipeline" \
+                --header "Circle-Token: ${CIRCLECI_API_TOKEN}" \
+                --header "content-type: application/json" \
+                --data "{\"parameters\":{\"e2e_env_name\":\"$env_name\",\"trigger_pipeline\":true}}")
+              if [[ $response == "201" ]]; then
+                echo "Env Release Pipeline triggered successfully. Exiting with success."
+                exit 0
+              else
+                echo "Failed to trigger pipeline. HTTP status code: $response"
+                exit 1
+              fi
+            fi
             vfcli env resume "$env_name" --interactive false
             vfcli track attach --branch master --components all --name "$env_name" --interactive false --no-circleci
             vfcli pool free-env --env-name "$env_name"

--- a/src/commands/vfcli/vfcli-resetdb-free-env.yml
+++ b/src/commands/vfcli/vfcli-resetdb-free-env.yml
@@ -13,5 +13,4 @@ steps:
         vfcli env resume "$env_name" --interactive false
         vfcli track attach --branch master --components all --name "$env_name" --interactive false --no-circleci
         vfcli env database reset --name "$env_name"
-        vfcli component restart --name "$env_name" --wait
         vfcli pool free-env --env-name "$env_name"

--- a/src/commands/vfcli/vfcli-resetdb-free-env.yml
+++ b/src/commands/vfcli/vfcli-resetdb-free-env.yml
@@ -3,7 +3,7 @@ description: Uses vfcli to reset database and free an environment back into the 
 parameters:
   env-name:
     type: string
-    description: Name of the environment to create
+    description: Name of the environment to reset database and free back into the pool
 steps:
   - run:
       name: Reset Database and Free Environment

--- a/src/commands/vfcli/vfcli-resetdb-free-env.yml
+++ b/src/commands/vfcli/vfcli-resetdb-free-env.yml
@@ -1,0 +1,17 @@
+description: Uses vfcli to reset database and free an environment back into the pool
+
+parameters:
+  env-name:
+    type: string
+    description: Name of the environment to create
+steps:
+  - run:
+      name: Reset Database and Free Environment
+      command: |
+        env_name="<< parameters.env-name >>"
+        echo "Releasing the environment..... $env_name"
+        vfcli env resume "$env_name" --interactive false
+        vfcli track attach --branch master --components all --name "$env_name" --interactive false --no-circleci
+        vfcli env database reset --name "$env_name"
+        vfcli component restart --name "$env_name" --wait
+        vfcli pool free-env --env-name "$env_name"

--- a/src/commands/vfcli/vfcli-resetdb-free-env.yml
+++ b/src/commands/vfcli/vfcli-resetdb-free-env.yml
@@ -13,4 +13,5 @@ steps:
         vfcli env resume "$env_name" --interactive false
         vfcli track attach --branch master --components all --name "$env_name" --interactive false --no-circleci
         vfcli env database reset --name "$env_name"
+        vfcli component restart --name "$env_name" --wait
         vfcli pool free-env --env-name "$env_name"

--- a/src/jobs/e2e/provision-env.yml
+++ b/src/jobs/e2e/provision-env.yml
@@ -21,6 +21,10 @@ parameters:
     type: string
     description: Pool where a free environment will be fetched
     default: ""
+  force:
+    type: boolean
+    description: Whether to force environment creation without checking for free environment
+    default: false
 steps:
   - install-vfcli:
       init-cluster: << parameters.cluster >>
@@ -32,6 +36,7 @@ steps:
       env-name: << parameters.env-name >>
       track-file: *track_file
       pool-type: << parameters.pool-type >>
+      force: << parameters.force >>
   - run:
       name: Get pod list
       command: kubectl get pods -n << parameters.env-name >>

--- a/src/jobs/e2e/release-env.yml
+++ b/src/jobs/e2e/release-env.yml
@@ -14,9 +14,14 @@ parameters:
     type: string
     description: When to run this command
     default: always
+  reset-db:
+    type: boolean
+    description: Whether to reset the database
+    default: false
 steps:
   - install-vfcli:
       init-cluster: << parameters.cluster >>
   - vfcli-delete-or-release-env:
       env-name: << parameters.env-name >>
+      reset-db: << parameters.reset-db >>
       when: << parameters.when >>

--- a/src/jobs/e2e/resetdb-free-env.yml
+++ b/src/jobs/e2e/resetdb-free-env.yml
@@ -1,0 +1,17 @@
+
+description: Release an environment from use by the e2e tests
+executor: default-executor
+
+parameters:
+  env-name:
+    type: string
+    description: Name of the environment to release
+  cluster:
+    type: string
+    description: Name of the cluster in which the environment exists
+    default: "cm4-vf-dev-br-2-0-p1"
+steps:
+  - install-vfcli:
+      init-cluster: << parameters.cluster >>
+  - vfcli-resetdb-free-env:
+      env-name: << parameters.env-name >>

--- a/src/jobs/smoke/report_smoke_failures.yml
+++ b/src/jobs/smoke/report_smoke_failures.yml
@@ -1,0 +1,28 @@
+executor: node-executor-node-20
+
+parameters:
+  e2e-env-name:
+    type: string
+    default: ""
+  branch-or-commit:
+    type: string
+    default: "master"
+    description: "the branch or commit of the automated-testing repo to reference for source code"
+  channel:
+    type: string
+    default: "test_failures"
+    description: "the channel where test failures reports will be posted"
+  mention:
+    type: string
+    default: "<!subteam^S07CKAVJPLG>"
+steps:
+  - authenticate_npm
+  - run:
+      name: Report Test Failures
+      command: |
+        npx --package=@voiceflow/test-cli -- \
+          testcli report \
+            --environment << parameters.e2e-env-name >> \
+            --smokeRef << parameters.branch-or-commit >> \
+            --channel << parameters.channel >> \
+            --mention '<< parameters.mention >>'

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -9,8 +9,13 @@ parameters:
   semantic_version:
     type: string
     default: ""
+  platform:
+    description: Platform to build the image for
+    type: string
+    default: linux/amd64
 steps:
   - update_database_track:
       component: "<< parameters.component >>"
       image_repo: "<< parameters.image_repo >>"
       semantic_version: '<< parameters.semantic_version >>'
+      platform: "<< parameters.platform >>"

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -67,6 +67,10 @@ parameters:
     description: The container image tag
     type: string
     default: ""
+  sem_ver_override:
+    description: Semantic release version of the package
+    type: string
+    default: ""
   kms_key:
     description: KMS Key to sign the containers
     type: string

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -91,6 +91,10 @@ parameters:
     description: enable docker layer cache
     type: boolean
     default: false
+  enable_push:
+    description: push the image to the registry
+    type: boolean
+    default: true
   builder_name:
     description: named builder for use with DLC
     type: string
@@ -125,3 +129,4 @@ steps:
       enable_load: "<< parameters.enable_load >>"
       builder_name: "<< parameters.builder_name >>"
       update_track_file: "<< parameters.update_track_file >>"
+      enable_push: "<< parameters.enable_push >>"

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -4,6 +4,7 @@
 # Expected env vars
 echo "IMAGE_REPO: ${IMAGE_REPO?}"
 echo "IMAGE_TAG_OVERRIDE: ${IMAGE_TAG_OVERRIDE?}"
+echo "SEM_VER_OVERRIDE: ${SEM_VER_OVERRIDE?}"
 echo "KMS_KEY: ${KMS_KEY?}"
 echo "PACKAGE: ${PACKAGE?}"
 echo "BUILD_CONTEXT: ${BUILD_CONTEXT?}"
@@ -55,6 +56,8 @@ if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "production" ]]; then
     else
         SEM_VER=$(git describe --abbrev=0 --tags)
     fi
+elif [[ "$SEM_VER_OVERRIDE" != "" ]]; then
+    SEM_VER=$SEM_VER_OVERRIDE
 else
     SEM_VER="$CIRCLE_BRANCH-$CIRCLE_SHA1"
 fi

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -17,6 +17,7 @@ echo "BUILDER_NAME: ${BUILDER_NAME-}"
 echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
 echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
 echo "ENABLE_LOAD: ${ENABLE_LOAD:=0}"
+echo "ENABLE_PUSH: ${ENABLE_PUSH:=0}"
 echo "UPDATE_TRACK_FILE: ${UPDATE_TRACK_FILE:=0}"
 
 
@@ -96,7 +97,11 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
       "${BUILDER_ARGS[@]}"
     docker buildx inspect --bootstrap
 
-    OUTPUT_ARGS=(--push)
+    OUTPUT_ARGS=()
+    if (( ENABLE_PUSH )); then
+      OUTPUT_ARGS+=(--push)
+    fi
+
     if (( ENABLE_LOAD )); then
       OUTPUT_ARGS+=(--load)
     fi


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-000**

### Brief description. What is this change?

This PR adds the following changes:
1. Refactor update database track job to use buildx
2. Add the ability to push or not a docker image using build
3. Add semantic override for database cli
4. fixes an issue with provision-env when force creating an environment

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test