### PR TITLE
feat: any branch can push its cache (PL-000)

### DIFF
--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -116,7 +116,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
       CACHE_FROM_ARG+=(--cache-from "${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
     fi
 
-    if [[ "${ENABLE_CACHE_TO-}" -eq 1  && "${BRANCH_NAME}" == "master" ]] ; then
+    if [[ "${ENABLE_CACHE_TO-}" -eq 1 ]] ; then
       CACHE_TO_ARG=(--cache-to "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
     fi
 
@@ -171,4 +171,3 @@ if (( UPDATE_TRACK_FILE )); then
 else
     echo "Skipping track update"
 fi
-


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
Lift the arbitrary limitation that only `master` branch could push it's cache image to remote registry. This was only done initially as a safety mechanism not to let the repo size get out of control. 

### Related PRs
- https://github.com/voiceflow/general-service/pull/600