### PR TITLE
fix: removed command that runs release twice

### DIFF
--- a/src/commands/vfcli/vfcli-delete-or-release-env.yml
+++ b/src/commands/vfcli/vfcli-delete-or-release-env.yml
@@ -43,7 +43,6 @@ steps:
             vfcli pool release-env --env-name "$env_name"
             if [[ << parameters.reset-db >> == true ]]; then
               echo "Resetting the database for $env_name"
-              vfcli pool release-env --env-name "$env_name"
               echo "Triggering pipeline with env-name parameter"
               response=$(curl -s -w "\n%{http_code}" \
                 --request POST \


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

Remove duplicate release command

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test