### PR TITLE
Use new E2E image for smoke tests

### DIFF
--- a/src/executors/node/e2e-executor.yml
+++ b/src/executors/node/e2e-executor.yml
@@ -9,7 +9,7 @@ parameters:
     default: xlarge
 resource_class: << parameters.default_resource_class >>
 docker: # run the steps with Docker
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v2-alpha1
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v2
     user: << parameters.user >>
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID

--- a/src/executors/node/e2e-executor.yml
+++ b/src/executors/node/e2e-executor.yml
@@ -9,7 +9,7 @@ parameters:
     default: xlarge
 resource_class: << parameters.default_resource_class >>
 docker: # run the steps with Docker
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v1
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v2-alpha1
     user: << parameters.user >>
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID

--- a/src/executors/node/smoke-executor.yml
+++ b/src/executors/node/smoke-executor.yml
@@ -1,5 +1,5 @@
 docker: # run the steps with Docker.
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v2-alpha1
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v2
     user: root
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID

--- a/src/executors/node/smoke-executor.yml
+++ b/src/executors/node/smoke-executor.yml
@@ -1,5 +1,5 @@
 docker: # run the steps with Docker.
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v1
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-e2e-image:v2-alpha1
     user: root
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Shaves ~30s off CI time because we don't have to re-pull every time.

See "already exists" messages here: https://app.circleci.com/pipelines/github/voiceflow/creator-app/219223/workflows/717dec82-a218-467d-adf9-cfb1cda3af90/jobs/950975