### PR TITLE
Use new node 20 image based off of CircleCI base image

### DIFF
--- a/src/executors/node/node-executor-node-20.yml
+++ b/src/executors/node/node-executor-node-20.yml
@@ -9,7 +9,7 @@ parameters:
     default: '4096'
   tag:
     type: string
-    default: 20.11.1-vf-4
+    default: 20.17-vf-5
 working_directory: ~/voiceflow
 docker:
   - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:<< parameters.tag >>


### PR DESCRIPTION
This shaves 30 seconds off of the build step, because we can use the cached CircleCI layers

passing build: https://app.circleci.com/pipelines/github/voiceflow/creator-app/219904/workflows/5d6a1af6-9aa5-4a6e-a037-778ccdd2b6c7