### PR TITLE
Add an executor specifically for gomplate

### DIFF
--- a/src/executors/gomplate/gomplate-executor.yml
+++ b/src/executors/gomplate/gomplate-executor.yml
@@ -1,0 +1,3 @@
+resource_class: medium+
+docker:
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-gomplate-image:v1


### PR DESCRIPTION
Add a smaller executor for running gomplate, otherwise you have to pull 500mb of node

Example of passing https://app.circleci.com/pipelines/github/voiceflow/creator-app/219910/workflows/f392ac40-fc86-4ae5-8b7c-a800c130a574

