### PR TITLE
feat: Make default executor use new node image

### DIFF
--- a/src/executors/node/default-executor-node-20.yml
+++ b/src/executors/node/default-executor-node-20.yml
@@ -5,7 +5,7 @@ parameters:
     default: medium
 working_directory: ~/voiceflow
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v3
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:20.17-v5
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/src/executors/node/default-executor.yml
+++ b/src/executors/node/default-executor.yml
@@ -5,7 +5,7 @@ parameters:
     default: medium
 working_directory: ~/voiceflow
 docker:
-  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:v4
+  - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-image:20.17-v5
     aws_auth:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This is one of the penultimate commits for the new images, by using circleCI's own docker images as a base, we can avoid re-pulling lots of data for every step of every pipeline.