### PR TITLE
feat: update golang version for K8s v1.30 upgrade:IN-1614

### DIFF
--- a/src/executors/golang/go-executor.yml
+++ b/src/executors/golang/go-executor.yml
@@ -1,3 +1,3 @@
 resource_class: medium+
 docker:
-  - image: cimg/go:1.21-node
+  - image: cimg/go:1.23-node


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [IN-1614](https://linear.app/voiceflow/issue/IN-1614/cloud-dependencies)

### Description
* Bump up golang version to 1.23 since the latest versions of our libraries need at least that version of go

### Related PR's 
* https://github.com/voiceflow/infracli/pull/107
* https://github.com/voiceflow/vfcli/pull/275
* https://github.com/voiceflow/warden/pull/75
* https://github.com/voiceflow/cloud/pull/111

### Checklist

- [x]  Tested in Cloud repo [PR](https://github.com/voiceflow/cloud/pull/111) on [build](https://app.circleci.com/pipelines/github/voiceflow/cloud/683/workflows/7c56d2d3-1c04-4de7-af9d-afeedddbba2e/jobs/566) 

