### PR TITLE
fix: trap failure (IN-1719)

### DIFF
--- a/src/commands/yarn/yarn_command.yml
+++ b/src/commands/yarn/yarn_command.yml
@@ -55,7 +55,7 @@ steps:
       condition: << parameters.wait >>
       steps:
         - run:
-            name: Waiting util other processes are finished
+            name: Waiting until other processes are finished
             command: <<include(scripts/yarn/wait_for_lock.sh)>>
 
   - when:

--- a/src/scripts/yarn/run_command.sh
+++ b/src/scripts/yarn/run_command.sh
@@ -7,7 +7,7 @@ echo "Running command: ${COMMAND:?}"
 for _ in $(seq 0 "${MAX_RETRIES:?}"); do
     if bash -c "${COMMAND?}"; then
         if (( ${SHOULD_REMOVE_LOCKFILE?} )); then
-            echo "Removing lock file ${LOCK_FILE?}" 
+            echo "Removing lock file ${LOCK_FILE?}"
             rm -rf "${LOCK_FILE}"
         fi
         exit 0
@@ -17,4 +17,5 @@ for _ in $(seq 0 "${MAX_RETRIES:?}"); do
 done
 
 echo "failed: ${COMMAND?}" >&2
+touch /tmp/failure
 exit 1


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

`trap` does not catch `ERR` when thrown in an `if` statement (or if it does, i'm just unsure of the flags to make it do so) since it would not cause the script to exit. This causes a long timeout in CI that are waiting on a success or failure signal. So I have added the failure signal (the existence of the file `/tmp/failure`) to the non-trap fail path as well.