### PR TITLE
fix: wait on env suspension (IN-000)

### DIFF
--- a/src/commands/vfcli/vfcli-suspend-env.yml
+++ b/src/commands/vfcli/vfcli-suspend-env.yml
@@ -30,4 +30,4 @@ steps:
           env_name="<< parameters.env-name >>"
         fi
 
-        vfcli env suspend "$env_name" --interactive false --track-file "<< parameters.track-file >>"
+        vfcli env suspend "$env_name" --interactive false --wait --track-file "<< parameters.track-file >>"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
Wait for env suspension before making changes to deployment. Likely cause is Flux reverting deployment changes before it knows the env is suspended