### PR TITLE
feat: conditional smoke test (IN-1732)

### DIFF
--- a/src/jobs/smoke/run-smoke-tests.yml
+++ b/src/jobs/smoke/run-smoke-tests.yml
@@ -29,7 +29,18 @@ parameters:
     type: string
     description: Path to the env_name file
     default: "/home/circleci/voiceflow/env_name.txt"
+  force_run:
+    type: boolean
+    description: Bypass conditional run checks
+    default: false
 steps:
+  - run:
+      name: "Check whether to skip smoke tests"
+      command: |
+        if ! ( [[ "${CIRCLE_BRANCH}" =~ ^(gtmq_.*|trying)$ ]] || (( << parameters.force_run >> )) ); then
+          echo "Skipping since branch is not gtmq_ or trying and not forcing execution"
+          circleci-agent step halt
+        fi
   - clone_repo:
       github_repo_name: automated-testing
       github_commit: << parameters.branch-or-commit >>
@@ -90,4 +101,3 @@ steps:
   - store_artifacts:
       path: apps/smoke-test-runner/cypress/logs
       destination: logs
-


### PR DESCRIPTION
### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Graphite follows GitHub required checks.
GitHub checks rely on target branch, but do not differentiate different rules for source branch of PRs.
We will enable run-smoke-tests as a required GH check, but only run for our gtmq_ and trying branches, and halting it by default for others. This should act as a pass in the checks so that branches can be added to the merge queue, and the merge queue draft PR will run the smoke tests
