### PR TITLE
feat: update-track always creates gtmq_ track (IN-1727)

### DIFF
--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -161,8 +161,10 @@ IMAGE_SHA=$(crane digest "$IMAGE_NAME")
 # Remove the sha256: string
 IMAGE_SHA="${IMAGE_SHA//sha256:/}"
 
+TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
 if (( IS_GTMQ )); then
     echo "Creating track for ${CIRCLE_BRANCH}"
+    echo "TRACK: $TRACK"
     aws s3 cp - "s3://$BUCKET/$TRACK" <<EOF
 ${COMPONENT}:
   image:
@@ -171,7 +173,6 @@ ${COMPONENT}:
 EOF
 elif (( UPDATE_TRACK_FILE )); then
     # update the track
-    TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
     echo "TRACK: $TRACK"
 
     # the file /tmp/$TRACK is downloaded in the check_track_exists step


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Brief description. What is this change?
Always need to create the track for gtmq_ tracks during update-track to be able to smoke test them. They don't exist until this point