### PR TITLE
feat: switch to new v1.30 clusters:IN-1370

### DIFF
--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -4,7 +4,7 @@ parameters:
     cluster:
       type: string
       description: Name of the cluster in which the environment exists
-      default: "cm4-vf-dev-br-2-0-p1"
+      default: "cm4-vf-dev-br-2-0-p2"
     e2e-env-name:
       type: string
       description: Name of the environment to collect logs from

--- a/src/jobs/e2e/prepare-env.yml
+++ b/src/jobs/e2e/prepare-env.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster in which the environment exists
-    default: "cm4-vf-dev-br-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p2"
   tracked-components:
     type: string
     description: Space-separated list of components to track the specified branch

--- a/src/jobs/e2e/provision-env.yml
+++ b/src/jobs/e2e/provision-env.yml
@@ -8,7 +8,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster to create the environment on
-    default: "cm4-vf-dev-br-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p2"
   tracked-components:
     type: string
     description: Space-separated list of components to track the specified branch

--- a/src/jobs/e2e/release-env.yml
+++ b/src/jobs/e2e/release-env.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster in which the environment exists
-    default: "cm4-vf-dev-br-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p2"
   when:
     type: string
     description: When to run this command

--- a/src/jobs/e2e/resetdb-free-env.yml
+++ b/src/jobs/e2e/resetdb-free-env.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster in which the environment exists
-    default: "cm4-vf-dev-br-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p2"
 steps:
   - install-vfcli:
       init-cluster: << parameters.cluster >>

--- a/src/jobs/e2e/run-e2e-tests.yml
+++ b/src/jobs/e2e/run-e2e-tests.yml
@@ -9,7 +9,7 @@ parameters:
   cluster:
     type: string
     description: Name of the cluster to create the environment on
-    default: "cm4-vf-dev-br-2-0-p1"
+    default: "cm4-vf-dev-br-2-0-p2"
   artifacts_path:
     description: The path within the repo where the e2e test artifacts will be stored
     type: string


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* [Linear IN-1370](https://linear.app/voiceflow/issue/IN-1370/upgrade-kubernetes-clusters-from-v127-to-v130)

### Brief description. What is this change?
* Point vfcli  to use the latest Kubernetes v1.30 clusters 

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test