### PR TITLE
fix: always create database track for gtmq (IN-1777)

### DIFF
--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -32,14 +32,16 @@ source "/tmp/IMAGE_STATUS"
 # shellcheck disable=SC1091
 source "/tmp/TRACK_STATUS"
 
-IS_GTMQ=$(grep -qE "^gtmq_" - <<<"${CIRCLE_BRANCH}" && echo 1 || echo 0)
+IS_GTMQ=$(grep -qE "^(gtmq_.*|trying)$" - <<<"${CIRCLE_BRANCH}" && echo 1 || echo 0)
 
 if [[ "$TRACK_EXISTS" != "true"  ]]; then
   if (( ! IS_GTMQ )); then
     echo "Track does not exist! avoiding update!"
     exit 0
   fi
+
   echo "Track will be created for merge queue branch"
+  echo 'export TRACK_EXISTS="true"' > /tmp/TRACK_STATUS  # Track exists, skip following steps
 fi
 
 if [[ -z "$CIRCLE_BRANCH" && -n "$CIRCLE_TAG" ]]; then


### PR DESCRIPTION
There is an additional step for database-cli that was initially missed causing timeouts on provision-env. Instead of adding the gtmq logic to that command as well, i've updated `update_track` to write back to the sourced `/tmp/TRACK_EXISTS` so the logic is contained in one place. This value is again sourced by `update_database_track` but should now have the correct value