### PR TITLE
feat: skip GH Commit Status

### DIFF
--- a/src/commands/github/create_commit_status.yml
+++ b/src/commands/github/create_commit_status.yml
@@ -1,0 +1,33 @@
+parameters:
+  check-name:
+    type: string
+    description: Name of the job to skip
+  status:
+    description: Status of check
+    type: enum
+    enum: ["error", "failure", "pending", "success"]
+  description:
+    description: Text that shows in GH checks
+    type: string
+steps:
+  - run:
+      name: "Setting << parameters.check-name >> check to << parameters.status >>"
+      environment:
+        CHECK_NAME: "<< parameters.check-name >>"
+        STATUS: "<< parameters.status >>"
+        DESCRIPTION: "<< parameters.description >>"
+      command: |
+        curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/voiceflow/${CIRCLE_PROJECT_REPONAME}/statuses/${CIRCLE_SHA1}" \
+            --data-binary @- \<<EOF
+        {
+          "state": "<< parameters.status >>",
+          "target_url": "https://app.circleci.com/pipelines/github/voiceflow/${CIRCLE_PROJECT_REPONAME}",
+          "description": "<< parameters.description >>",
+          "context": "<< parameters.check-name >>"
+        }
+        EOF

--- a/src/jobs/github/create_commit_status.yml
+++ b/src/jobs/github/create_commit_status.yml
@@ -1,0 +1,19 @@
+description: Create GH "Commit Status"
+docker:
+  - image: cimg/base:current-22.04
+parameters:
+  check-name:
+    type: string
+    description: Name of the job to skip
+  status:
+    description: Status of check
+    type: enum
+    enum: ["error", "failure", "pending", "success"]
+  description:
+    description: Text that shows in GH checks
+    type: string
+steps:
+  - create_commit_status:
+      check-name: << parameters.check-name >>
+      status: << parameters.status >>
+      description: << parameters.description >>


### PR DESCRIPTION
Create a GH Commit Status

Used to skip "Commit Status" checks that run for entering merge queue but shouldn't run on the merge queue branch, such as "UI Tests" in `react-chat` and `design` repos