### PR TITLE
fix: redirect stdout to file (IN-1855)

### DIFF
--- a/src/jobs/e2e/collect-e2e-logs.yml
+++ b/src/jobs/e2e/collect-e2e-logs.yml
@@ -97,7 +97,7 @@ steps:
           # Iterate over the components. Process log collection in parallel as background processes
           for component in "${components[@]}"; do
             echo "Capturing logs for component $component"
-            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" "${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" --since 5m &
+            stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" --since 5m >>"${LOG_DIR:?}/${COMPONENT_LOG_DIR:?}/$component.log" &
           done
 
           wait


### PR DESCRIPTION
Changes that weren't supposed to go in also broke the `stern` logging. This fixes by adding back in the redirect stdout to file