### PR TITLE
fix: restore cache to get env_name.txt for report_smoke_failures (IN-000)

### DIFF
--- a/src/jobs/smoke/report_smoke_failures.yml
+++ b/src/jobs/smoke/report_smoke_failures.yml
@@ -20,6 +20,8 @@ parameters:
     type: string
     default: "<!subteam^S07CKAVJPLG>"
 steps:
+  - restore_cache:
+      key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   - authenticate_npm
   - run:
       name: Report Test Failures


### PR DESCRIPTION
fix: restore cache to get env_name.txt for report_smoke_failures. Otherwise it uses the ENV VAR, which is usually wrong.

Code copied from `collect-e2e-logs` jobs, verified by checking set cache from `src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml`: 
```  - save_cache:
      key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
      paths:
        - env_name.txt
```