### PR TITLE
fix: bump playwright executor (RUN-476)

### DIFF
--- a/src/executors/node/playwright-executor.yml
+++ b/src/executors/node/playwright-executor.yml
@@ -3,4 +3,4 @@ parameters:
     type: string
 docker: # run the steps with Docker.
   - image: mcr.microsoft.com/playwright:v<< parameters.playwright-version >>-noble
-resource_class: xlarge
+resource_class: 2xlarge


### PR DESCRIPTION
playwright is now the bottleneck in our deployment pipeline, by about 2 minutes.
<img width="834" alt="Capture d’écran, le 2024-12-18 à 09 27 44" src="https://github.com/user-attachments/assets/6ac5f1ed-f948-43a3-b97d-cbaae16857b3" />

We have to raise the executor here before raising it in `automated-testing`, because if we increase the parallelism in `automated-testing`, all other repos will fail