### PR TITLE
fix: use updated name for testcli report command (QLT-372)

### DIFF
--- a/src/jobs/smoke/report_smoke_failures.yml
+++ b/src/jobs/smoke/report_smoke_failures.yml
@@ -34,7 +34,7 @@ steps:
         fi
 
         npx --package=@voiceflow/test-cli -- \
-          testcli report \
+          testcli report pull-request \
             --environment "${env_name}" \
             --smokeRef << parameters.branch-or-commit >> \
             --channel << parameters.channel >> \


### PR DESCRIPTION
So we can remove this alias and use the updated command name

https://github.com/voiceflow/automated-testing/blob/master/apps/test-cli/src/commands/report/index.ts#L3