### PR TITLE
feat: add command to install latest hadolint (IN-2335)

### DIFF
--- a/src/commands/monorepo/monorepo_lint_dockerfile.yml
+++ b/src/commands/monorepo/monorepo_lint_dockerfile.yml
@@ -16,6 +16,7 @@ parameters:
     type: boolean
     default: false
 steps:
+  - install_latest_hadolint
   - monorepo_exec_command:
       step_name: << parameters.step_name >>
       command: yarn lint:dockerfiles

--- a/src/commands/utils/install_latest_hadolint.yml
+++ b/src/commands/utils/install_latest_hadolint.yml
@@ -1,0 +1,14 @@
+steps:
+  - run:
+      name: Install Latest Hadolint
+      command: |
+        curl -L \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/hadolint/hadolint/releases/latest |
+          jq -r ".assets[] | select(.name == \"hadolint-$(uname -o | sed 's/.*\///g')-$(uname -m)\") | .browser_download_url" |
+          xargs curl -Lo hadolint
+
+        sudo chown root:root ./hadolint
+        sudo chmod 755 ./hadolint
+        sudo mv hadolint $(which hadolint)


### PR DESCRIPTION
Install the latest version of hadolint from github releases before running `monorepo_lint_dockerfile`