### PR TITLE
feat: add DataDog Universal Service Tags and git repo as image Labels (IN-2365)

### DIFF
--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -139,13 +139,24 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
     TAGS+=(-t "$IMAGE_REPO:k8s-$BRANCH_NAME-$CIRCLE_SHA1")
   fi
 
+  LEGACY_BUILD_ARGS=(
+    --build-arg build_BUILD_NUM="${CIRCLE_BUILD_NUM}"
+    --build-arg build_GITHUB_TOKEN="${GITHUB_TOKEN}"
+    --build-arg build_BUILD_URL="${CIRCLE_BUILD_URL}"
+    --build-arg build_GIT_SHA="${CIRCLE_SHA1}"
+    --build-arg build_SEM_VER="${SEM_VER}"
+  )
+
+  DATADOG_LABELS=(
+    --label "com.datadoghq.tags.service=${COMPONENT}"
+    --label "com.datadoghq.tags.version=${build_GIT_SHA}"
+    --label "com.datadoghq.tags.git.commit.sha=${build_GIT_SHA}"
+    --label "com.datadoghq.tags.git.repository_url=${CIRCLE_REPOSITORY_URL}"
+  )
+
   echo "BUILD_ARGS: ${BUILD_ARGS[*]} $PLATFORM"
   docker buildx build \
-    --build-arg build_BUILD_NUM="${CIRCLE_BUILD_NUM}" \
-    --build-arg build_GITHUB_TOKEN="${GITHUB_TOKEN}" \
-    --build-arg build_BUILD_URL="${CIRCLE_BUILD_URL}" \
-    --build-arg build_GIT_SHA="${CIRCLE_SHA1}" \
-    --build-arg build_SEM_VER="${SEM_VER}" \
+    "${LEGACY_BUILD_ARGS[@]}" \
     "${DD_TAGS_ARG[@]}" \
     "${REGISTRY_ARG[@]}" \
     "${PACKAGE_ARG[@]}" \
@@ -153,6 +164,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
     "${NPM_TOKEN_SECRET[@]}" \
     "${BUILD_ARGS[@]}" \
     "${OUTPUT_ARGS[@]}" \
+    "${DATADOG_LABELS[@]}" \
     --platform "$PLATFORM" \
     -f "$BUILD_CONTEXT/$DOCKERFILE" \
     "${TAGS[@]}" \

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -21,9 +21,8 @@ echo "ENABLE_LOAD: ${ENABLE_LOAD:=0}"
 echo "ENABLE_PUSH: ${ENABLE_PUSH:=0}"
 echo "UPDATE_TRACK_FILE: ${UPDATE_TRACK_FILE:=0}"
 
-
 # force string to array
-read -r -a EXTRA_BUILD_ARGS <<< "$EXTRA_BUILD_ARGS"
+read -r -a EXTRA_BUILD_ARGS <<<"$EXTRA_BUILD_ARGS"
 
 # Load IMAGE_EXISTS variable from file previously stored in the tmp folder
 # shellcheck disable=SC1091
@@ -34,20 +33,20 @@ source "/tmp/TRACK_STATUS"
 
 IS_GTMQ=$(grep -qE "^gtmq_" - <<<"${CIRCLE_BRANCH}" && echo 1 || echo 0)
 
-if [[ "$TRACK_EXISTS" != "true"  ]]; then
-  if (( ! IS_GTMQ )); then
+if [[ "$TRACK_EXISTS" != "true" ]]; then
+  if ((!IS_GTMQ)); then
     echo "Track does not exist! avoiding update!"
     exit 0
   fi
 
   echo "Track will be created for merge queue branch"
-  echo 'export TRACK_EXISTS="true"' > /tmp/TRACK_STATUS  # Track exists, skip following steps
+  echo 'export TRACK_EXISTS="true"' >/tmp/TRACK_STATUS # Track exists, skip following steps
 fi
 
 if [[ -z "$CIRCLE_BRANCH" && -n "$CIRCLE_TAG" ]]; then
-    BRANCH_NAME="master"
+  BRANCH_NAME="master"
 else
-    BRANCH_NAME="${CIRCLE_BRANCH//[^[:alnum:]]/-}" # Change all non alphanumeric characters to -
+  BRANCH_NAME="${CIRCLE_BRANCH//[^[:alnum:]]/-}" # Change all non alphanumeric characters to -
 fi
 
 IMAGE_TAG="${IMAGE_TAG_OVERRIDE:-"k8s-$CIRCLE_SHA1"}"
@@ -55,114 +54,114 @@ IMAGE_TAG="${IMAGE_TAG_OVERRIDE:-"k8s-$CIRCLE_SHA1"}"
 IMAGE_NAME="$IMAGE_REPO:$IMAGE_TAG"
 # Get the tag that is running right now
 if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "production" ]]; then
-    # Update the tags
-    git fetch --tags
-    if [[ -n "$PACKAGE" ]]; then
-        SEM_VER=$(git describe --abbrev=0 --tags --match "@voiceflow/$PACKAGE@*")
-        SEM_VER="${SEM_VER##*@}"
-    else
-        SEM_VER=$(git describe --abbrev=0 --tags)
-    fi
+  # Update the tags
+  git fetch --tags
+  if [[ -n "$PACKAGE" ]]; then
+    SEM_VER=$(git describe --abbrev=0 --tags --match "@voiceflow/$PACKAGE@*")
+    SEM_VER="${SEM_VER##*@}"
+  else
+    SEM_VER=$(git describe --abbrev=0 --tags)
+  fi
 elif [[ "$SEM_VER_OVERRIDE" != "" ]]; then
-    SEM_VER=$SEM_VER_OVERRIDE
+  SEM_VER=$SEM_VER_OVERRIDE
 else
-    SEM_VER="$CIRCLE_BRANCH-$CIRCLE_SHA1"
+  SEM_VER="$CIRCLE_BRANCH-$CIRCLE_SHA1"
 fi
 
 # In a monorepo we need to copy the yarn lock file from root
 if [[ ! -f "$BUILD_CONTEXT/yarn.lock" && -f "yarn.lock" ]]; then
-    echo "Copying yarn.lock file from root"
-    cp yarn.lock "$BUILD_CONTEXT/yarn.lock"
+  echo "Copying yarn.lock file from root"
+  cp yarn.lock "$BUILD_CONTEXT/yarn.lock"
 fi
 
 echo -e "Building with SEM_VER=$SEM_VER"
 
 if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "production" ]]; then
-    # Build Docker Image
-    echo "Image not found, building..."
+  # Build Docker Image
+  echo "Image not found, building..."
 
-    if (( LOCAL_REGISTRY )); then
-        REGISTRY_ARG=(--network host --build-arg build_REGISTRY_URL=http://localhost:4873)
-    else
-        REGISTRY_ARG=(--build-arg NPM_TOKEN=//registry.npmjs.org/:_authToken="${NPM_TOKEN}")
-    fi
+  if ((LOCAL_REGISTRY)); then
+    REGISTRY_ARG=(--network host --build-arg build_REGISTRY_URL=http://localhost:4873)
+  else
+    REGISTRY_ARG=(--build-arg NPM_TOKEN=//registry.npmjs.org/:_authToken="${NPM_TOKEN}")
+  fi
 
-    if [[ -n "$PACKAGE" ]]; then
-        PACKAGE_ARG=(--build-arg APP_NAME="$PACKAGE")
-    fi
+  if [[ -n "$PACKAGE" ]]; then
+    PACKAGE_ARG=(--build-arg APP_NAME="$PACKAGE")
+  fi
 
-    if (( INJECT_AWS_CREDENTIALS )); then
-        AWS_CREDENTIALS_ARG=(--build-arg AWS_REGION="${AWS_REGION}" --build-arg AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" --build-arg AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}")
-    fi
+  if ((INJECT_AWS_CREDENTIALS)); then
+    AWS_CREDENTIALS_ARG=(--build-arg AWS_REGION="${AWS_REGION}" --build-arg AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" --build-arg AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}")
+  fi
 
-    for arg in "${EXTRA_BUILD_ARGS[@]}" ; do
-      BUILD_ARGS+=(--build-arg "${arg}")
-    done
+  for arg in "${EXTRA_BUILD_ARGS[@]}"; do
+    BUILD_ARGS+=(--build-arg "${arg}")
+  done
 
-    # NOTE: think of this as the CircleCI DLC key
-    echo "BUILDER_NAME: ${BUILDER_NAME:=buildy-${BRANCH_NAME-}}"
+  # NOTE: think of this as the CircleCI DLC key
+  echo "BUILDER_NAME: ${BUILDER_NAME:=buildy-${BRANCH_NAME-}}"
 
-    BUILDER_ARGS=(--name "${BUILDER_NAME-}")
-    docker buildx create --use --platform="$PLATFORM" \
-      "${BUILDER_ARGS[@]}"
-    docker buildx inspect --bootstrap
+  BUILDER_ARGS=(--name "${BUILDER_NAME-}")
+  docker buildx create --use --platform="$PLATFORM" \
+    "${BUILDER_ARGS[@]}"
+  docker buildx inspect --bootstrap
 
-    OUTPUT_ARGS=()
-    if (( ENABLE_PUSH )); then
-      OUTPUT_ARGS+=(--push)
-    fi
+  OUTPUT_ARGS=()
+  if ((ENABLE_PUSH)); then
+    OUTPUT_ARGS+=(--push)
+  fi
 
-    if (( ENABLE_LOAD )); then
-      OUTPUT_ARGS+=(--load)
-    fi
+  if ((ENABLE_LOAD)); then
+    OUTPUT_ARGS+=(--load)
+  fi
 
-    NPM_TOKEN_SECRET=(--secret id=NPM_TOKEN)
+  NPM_TOKEN_SECRET=(--secret id=NPM_TOKEN)
 
-    CACHE_FROM_ARG=(--cache-from "${IMAGE_REPO-}:cache-master")
-    if [ "${BRANCH_NAME}" != "master" ] ; then
-      CACHE_FROM_ARG+=(--cache-from "${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
-    fi
+  CACHE_FROM_ARG=(--cache-from "${IMAGE_REPO-}:cache-master")
+  if [ "${BRANCH_NAME}" != "master" ]; then
+    CACHE_FROM_ARG+=(--cache-from "${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
+  fi
 
-    if [[ "${ENABLE_CACHE_TO-}" -eq 1 ]] ; then
-      CACHE_TO_ARG=(--cache-to "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
-    fi
+  if [[ "${ENABLE_CACHE_TO-}" -eq 1 ]]; then
+    CACHE_TO_ARG=(--cache-to "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${IMAGE_REPO-}:cache-${BRANCH_NAME-}")
+  fi
 
-    BUILD_ARGS+=( "${CACHE_FROM_ARG[@]}" )
-    BUILD_ARGS+=( "${CACHE_TO_ARG[@]}" )
-    BUILD_ARGS+=( --builder "${BUILDER_NAME-}")
+  BUILD_ARGS+=("${CACHE_FROM_ARG[@]}")
+  BUILD_ARGS+=("${CACHE_TO_ARG[@]}")
+  BUILD_ARGS+=(--builder "${BUILDER_NAME-}")
 
-    DD_TAGS_ARG+=(--build-arg DD_GIT_REPOSITORY_URL="${CIRCLE_REPOSITORY_URL}")
+  DD_TAGS_ARG+=(--build-arg DD_GIT_REPOSITORY_URL="${CIRCLE_REPOSITORY_URL}")
 
-    TAGS=(-t "$IMAGE_NAME")
+  TAGS=(-t "$IMAGE_NAME")
 
-    if [[ -z "$IMAGE_TAG_OVERRIDE" ]]; then
-        TAGS+=(-t "$IMAGE_REPO:latest-$BRANCH_NAME")
-        TAGS+=(-t "$IMAGE_REPO:k8s-$BRANCH_NAME-$CIRCLE_SHA1")
-    fi
+  if [[ -z "$IMAGE_TAG_OVERRIDE" ]]; then
+    TAGS+=(-t "$IMAGE_REPO:latest-$BRANCH_NAME")
+    TAGS+=(-t "$IMAGE_REPO:k8s-$BRANCH_NAME-$CIRCLE_SHA1")
+  fi
 
-    echo "BUILD_ARGS: ${BUILD_ARGS[*]} $PLATFORM"
-    docker buildx build \
-        --build-arg build_BUILD_NUM="${CIRCLE_BUILD_NUM}" \
-        --build-arg build_GITHUB_TOKEN="${GITHUB_TOKEN}" \
-        --build-arg build_BUILD_URL="${CIRCLE_BUILD_URL}" \
-        --build-arg build_GIT_SHA="${CIRCLE_SHA1}" \
-        --build-arg build_SEM_VER="${SEM_VER}" \
-        "${DD_TAGS_ARG[@]}" \
-        "${REGISTRY_ARG[@]}" \
-        "${PACKAGE_ARG[@]}" \
-        "${AWS_CREDENTIALS_ARG[@]}" \
-        "${NPM_TOKEN_SECRET[@]}" \
-        "${BUILD_ARGS[@]}" \
-        "${OUTPUT_ARGS[@]}" \
-        --platform "$PLATFORM" \
-        -f "$BUILD_CONTEXT/$DOCKERFILE" \
-        "${TAGS[@]}" \
-        "$BUILD_CONTEXT"
+  echo "BUILD_ARGS: ${BUILD_ARGS[*]} $PLATFORM"
+  docker buildx build \
+    --build-arg build_BUILD_NUM="${CIRCLE_BUILD_NUM}" \
+    --build-arg build_GITHUB_TOKEN="${GITHUB_TOKEN}" \
+    --build-arg build_BUILD_URL="${CIRCLE_BUILD_URL}" \
+    --build-arg build_GIT_SHA="${CIRCLE_SHA1}" \
+    --build-arg build_SEM_VER="${SEM_VER}" \
+    "${DD_TAGS_ARG[@]}" \
+    "${REGISTRY_ARG[@]}" \
+    "${PACKAGE_ARG[@]}" \
+    "${AWS_CREDENTIALS_ARG[@]}" \
+    "${NPM_TOKEN_SECRET[@]}" \
+    "${BUILD_ARGS[@]}" \
+    "${OUTPUT_ARGS[@]}" \
+    --platform "$PLATFORM" \
+    -f "$BUILD_CONTEXT/$DOCKERFILE" \
+    "${TAGS[@]}" \
+    "$BUILD_CONTEXT"
 
-    IMAGE_DIGEST=$(crane digest "$IMAGE_NAME")
+  IMAGE_DIGEST=$(crane digest "$IMAGE_NAME")
 
-    # Signing Docker Image
-    cosign sign --key "$KMS_KEY" "$IMAGE_REPO@$IMAGE_DIGEST"
+  # Signing Docker Image
+  cosign sign --key "$KMS_KEY" "$IMAGE_REPO@$IMAGE_DIGEST"
 fi
 
 IMAGE_SHA=$(crane digest "$IMAGE_NAME")
@@ -170,26 +169,26 @@ IMAGE_SHA=$(crane digest "$IMAGE_NAME")
 IMAGE_SHA="${IMAGE_SHA//sha256:/}"
 
 TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
-if (( IS_GTMQ )); then
-    echo "Creating track for ${CIRCLE_BRANCH}"
-    echo "TRACK: $TRACK"
-    mkdir -p "$(dirname "/tmp/$TRACK")"
-    cat - <<EOF >"/tmp/$TRACK"
+if ((IS_GTMQ)); then
+  echo "Creating track for ${CIRCLE_BRANCH}"
+  echo "TRACK: $TRACK"
+  mkdir -p "$(dirname "/tmp/$TRACK")"
+  cat - <<EOF >"/tmp/$TRACK"
 ${COMPONENT}:
   image:
     tag: ${IMAGE_TAG}
     sha: ${IMAGE_SHA}
 EOF
 
-    aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
-elif (( UPDATE_TRACK_FILE )); then
-    # update the track
-    echo "TRACK: $TRACK"
+  aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
+elif ((UPDATE_TRACK_FILE)); then
+  # update the track
+  echo "TRACK: $TRACK"
 
-    # the file /tmp/$TRACK is downloaded in the check_track_exists step
-    yq -y -i --arg tag "${IMAGE_TAG}" ".\"$COMPONENT\".image.tag=\$tag" "/tmp/$TRACK"
-    yq -y -i --arg sha "${IMAGE_SHA}" ".\"$COMPONENT\".image.sha=\$sha" "/tmp/$TRACK"
-    aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
+  # the file /tmp/$TRACK is downloaded in the check_track_exists step
+  yq -y -i --arg tag "${IMAGE_TAG}" ".\"$COMPONENT\".image.tag=\$tag" "/tmp/$TRACK"
+  yq -y -i --arg sha "${IMAGE_SHA}" ".\"$COMPONENT\".image.sha=\$sha" "/tmp/$TRACK"
+  aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
 else
-    echo "Skipping track update"
+  echo "Skipping track update"
 fi


### PR DESCRIPTION
## Description
Add The DataDog Universal Service Tags and Git Repo Tags as image labels at build time. Doing so here standardizes across all services.

The same info as Env Vars can either be added in the Dockerfiles, and/or, at run time

Example in `general-service` with only a dev orb change: 
```
% BEFORE="168387678261.dkr.ecr.us-east-1.amazonaws.com/general-service:k8s-9deb190c4038afee230accfe34c179f7d22bff1c"
% AFTER="168387678261.dkr.ecr.us-east-1.amazonaws.com/general-service:k8s-d3b8f2246ec7bc8056ccae1e1eb10d830f157497"
% docker image inspect $BEFORE | jq -C '.[0].Config.Labels'
null
% docker image inspect $AFTER | jq -C '.[0].Config.Labels'
{
  "com.datadoghq.tags.git.commit.sha": "",
  "com.datadoghq.tags.git.repository_url": "git@github.com:voiceflow/general-service.git",
  "com.datadoghq.tags.service": "general-service",
  "com.datadoghq.tags.version": ""
}