### PR TITLE
fix: only create a gtmq track if UPDATE_TRACK_FILE is also true (IN-2735)

### DIFF
--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -181,7 +181,7 @@ IMAGE_SHA=$(crane digest "$IMAGE_NAME")
 IMAGE_SHA="${IMAGE_SHA//sha256:/}"
 
 TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
-if ((IS_GTMQ)); then
+if ((IS_GTMQ)) && ((UPDATE_TRACK_FILE)); then
   echo "Creating track for ${CIRCLE_BRANCH}"
   echo "TRACK: $TRACK"
   mkdir -p "$(dirname "/tmp/$TRACK")"


### PR DESCRIPTION
## Description
`update_track` should respect the `UDPATE_TRACK_FILE` flag even for gtmq branches so that we can create the track in `create_manifest` where appropriate