### PR TITLE
fix: ensure track exists in update_database_track (IN-2761)

### DIFF
--- a/src/scripts/track/update_database_track.sh
+++ b/src/scripts/track/update_database_track.sh
@@ -6,12 +6,13 @@ source "/tmp/TRACK_STATUS"
 
 echo "New version published: ${SEM_VER}"
 
-if [[ $TRACK_EXISTS == "true"  && -n "$SEM_VER" ]]; then
-    # update the track
-    TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
-    echo "$TRACK"
-    echo "$SEM_VER" > "/tmp/$TRACK"
-    aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
+if [[ $TRACK_EXISTS == "true" && -n "$SEM_VER" ]]; then
+  # update the track
+  TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
+  echo "$TRACK"
+  echo "$SEM_VER" >"/tmp/$TRACK"
+  aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
 else
-    echo "Track does not exist! avoiding update!"
+  echo "Track does not exist! avoiding update!"
 fi
+

--- a/src/scripts/track/update_database_track.sh
+++ b/src/scripts/track/update_database_track.sh
@@ -10,6 +10,7 @@ if [[ $TRACK_EXISTS == "true" && -n "$SEM_VER" ]]; then
   # update the track
   TRACK="tracks/$COMPONENT/$CIRCLE_BRANCH"
   echo "$TRACK"
+  mkdir -p "$(dirname "/tmp/$TRACK")"
   echo "$SEM_VER" >"/tmp/$TRACK"
   aws s3 cp "/tmp/$TRACK" "s3://$BUCKET/$TRACK"
 else


### PR DESCRIPTION
## Description
We shouldn't need 2 different builder based on whether it is database cli or not. But this is a small fix to ensure track exists in update_database_track, as it's just a filename issue.

