### PR TITLE
fix: up node memory for yarn build command (IN-2763)

### DIFF
--- a/src/commands/yarn/build.yml
+++ b/src/commands/yarn/build.yml
@@ -55,4 +55,4 @@ steps:
       monorepo_package_folder: << parameters.package_folder >>
       step_name: << parameters.step_name >>
       wait: << parameters.wait >>
-      yarn_command: yarn build<<# parameters.package >>:<</ parameters.package >><< parameters.package >> << parameters.extra_args >>
+      yarn_command: NODE_OPTIONS=--max_old_space_size=4096 yarn build<<# parameters.package >>:<</ parameters.package >><< parameters.package >> << parameters.extra_args >>

--- a/src/commands/yarn/build.yml
+++ b/src/commands/yarn/build.yml
@@ -2,7 +2,7 @@ parameters:
   working_directory:
     description: Directory containing package.json
     type: string
-    default: './'
+    default: "./"
   run_in_background:
     description: run the command in background
     type: boolean

--- a/src/jobs/yarn/install_and_build.yml
+++ b/src/jobs/yarn/install_and_build.yml
@@ -53,7 +53,7 @@ parameters:
     type: string
     default: "168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-node-build-image:v1"
   force_execute:
-    description: '[DEPRECATED] no effect, kept for backward compatibility'
+    description: "[DEPRECATED] no effect, kept for backward compatibility"
     type: boolean
     default: false
   attach_workspace:


### PR DESCRIPTION
## Description

This job/command/script for `yarn build` should probably be deprecated and anything using it should be modernized. But this (increasing memory for node) is a quick fix to unblock `general-service` builds and shouldn't have a negative effect on other builds, but if it does, those should be taken note of to be updated as well.
