### PR TITLE
fix: use CIRCLE_TOKEN for circleci-cli orb update (IN-2754)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ update_common_orb_context: &update_common_orb_context
 
         echo "Updating ORB_RELEASE_VERSION: ${ORB_RELEASE_VERSION}"
         # value set through stdin
-        echo "$ORB_RELEASE_VERSION" | circleci context store-secret --org-id "$ORG_ID" dev-test COMMON_ORB_VERSION
+        echo "$ORB_RELEASE_VERSION" | circleci context store-secret --token "$CIRCLE_TOKEN" --org-id "$ORG_ID" dev-test COMMON_ORB_VERSION
 
 workflows:
   publish-dev-orb:


### PR DESCRIPTION
## Description
Was missing the token for updating context

Test:
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/466aba15-9270-4cfe-a689-2043007e1ae0" />

Before
<img width="897" alt="image" src="https://github.com/user-attachments/assets/b641feb6-9782-4006-8c11-004abc2be4a4" />
After
<img width="885" alt="image" src="https://github.com/user-attachments/assets/acd2a586-89d7-408c-be21-fc75ff0d645a" />
