### PR TITLE
chore: upgrade build-executor default to ci-image:25.05-dind-vf-4

### DIFF
--- a/src/executors/node/build-executor.yml
+++ b/src/executors/node/build-executor.yml
@@ -5,7 +5,7 @@ parameters:
     default: medium
   tag:
     type: string
-    default: 25.0.5-dind-vf-2
+    default: 25.0.5-dind-vf-4
 working_directory: ~/voiceflow
 docker:
   - image: 168387678261.dkr.ecr.us-east-1.amazonaws.com/ci-image:<< parameters.tag >>

--- a/src/jobs/docker/create_manifest.yml
+++ b/src/jobs/docker/create_manifest.yml
@@ -1,6 +1,5 @@
 executor:
   name: build-executor
-  tag: 25.0.5-dind-alpha-multi
 parameters:
   image_repo:
     description: repo


### PR DESCRIPTION
chore: upgrade build-executor default to ci-image:25.05-dind-vf-4

chore: remove default alpha tag for create_manifest job