### PR TITLE
fix: check_wait_master PAGE_TOKEN substitution (IN-000)

### DIFF
--- a/src/scripts/utils/check_wait_master.sh
+++ b/src/scripts/utils/check_wait_master.sh
@@ -13,7 +13,8 @@ list_pipelines() {
   # get paginated list of master pipelines for specified repo
   ##
   local PAGE_TOKEN
-  PAGE_TOKEN="${1+&page-token=${1}}"
+  PAGE_TOKEN="$1"
+  PAGE_TOKEN="${PAGE_TOKEN:+&page-token=${PAGE_TOKEN}}"
   curl --fail --silent --request GET \
     --url "https://circleci.com/api/v2/project/${ORG}/${PROJECT}/pipeline?branch=${BRANCH}${PAGE_TOKEN}" \
     --header "Circle-Token: ${CIRCLECI_API_TOKEN}"


### PR DESCRIPTION
Had thought i collapsed this to be the same but shorter, but apparently changed the logic. so reverting so PAGE_TOKEN isn't included in the query params if not set as param of function