### PR TITLE
feat: use master tracks for tag and copy to production track (IN-3005)

### DIFF
--- a/src/scripts/track/promote_production.sh
+++ b/src/scripts/track/promote_production.sh
@@ -45,7 +45,7 @@ parse_tag() {
     # The full contents of database-cli track is the image tag
     cat "${TRACK_PATH_ABSOLUTE}"
   else
-    yq ".[\"$COMPONENT\"].image.tag" "${TRACK_PATH_ABSOLUTE}"
+    yq -r ".[\"$COMPONENT\"].image.tag" "${TRACK_PATH_ABSOLUTE}"
   fi
 }
 


### PR DESCRIPTION
## Description
Use the `master` tracks as the source of truth on the latest tag for a service. use the `tag` field to update `latest-production` tag, and copy the full track file to `production` track