### PR TITLE
fix: fail on timeout waiting for master success (IN-3059)

### DIFF
--- a/src/scripts/utils/check_wait_master.sh
+++ b/src/scripts/utils/check_wait_master.sh
@@ -73,7 +73,7 @@ while [[ "$((COUNT++))" -lt "$MAX_RETRY" ]]; do
 
     "success")
       echo "Found master workflow successfully completed"
-      break
+      exit 0
       ;;
 
     *)
@@ -83,4 +83,5 @@ while [[ "$((COUNT++))" -lt "$MAX_RETRY" ]]; do
   esac
 done
 
-echo "continuing"
+echo "Timing out"
+exit 1


### PR DESCRIPTION
## Description
Timing out would result in continuing the deployment instead of failing, results in deploying a previous version of master (from tracks)