### PR TITLE
chore: remove platform as param for update_track (IN-3157)

### DIFF
--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -120,7 +120,6 @@ steps:
       kms_key: "<< parameters.kms_key >>"
       inject_aws_credentials: "<< parameters.inject_aws_credentials >>"
       local_registry_container_image: "<< parameters.local_registry_container_image >>"
-      platform: "<< parameters.platform >>"
       enable_dlc: "<< parameters.enable_dlc >>"
       enable_load: "<< parameters.enable_load >>"
       builder_name: "<< parameters.builder_name >>"

--- a/src/commands/track/update_database_track.yml
+++ b/src/commands/track/update_database_track.yml
@@ -18,10 +18,6 @@ parameters:
     description: Name of the Dockerfile to build
     type: string
     default: Dockerfile
-  extra_build_args:
-    description: Arguments to pass while building the docker image
-    type: string
-    default: ""
   enable_load:
     description: Load image into local docker
     type: boolean
@@ -98,12 +94,15 @@ parameters:
     description: checks if the track exists
     type: boolean
     default: true
+  node_version:
+    description: Node version
+    type: string
 steps:
   - update_track:
       image_repo: "<< parameters.image_repo >>"
       component: "<< parameters.component >>"
       dockerfile: "<< parameters.dockerfile >>"
-      extra_build_args: << parameters.extra_build_args >>
+      extra_build_args: "NODE_VERSION=<< parameters.node_version >>"
       enable_cache_to: "<< parameters.enable_cache_to >>"
       build_context: "<< parameters.build_context >>"
       checkout: "<< parameters.checkout >>"

--- a/src/commands/track/update_track.yml
+++ b/src/commands/track/update_track.yml
@@ -13,7 +13,7 @@ parameters:
   extra_build_args:
     description: Arguments to pass while building the docker image
     type: string
-    default: ''
+    default: ""
   enable_cache_to:
     description: use --cache-to flag to push cache artifact to remote registry
     type: boolean
@@ -21,7 +21,7 @@ parameters:
   build_context:
     description: Path to the context for the docker build
     type: string
-    default: '.'
+    default: "."
   checkout:
     description: Determines if a checkout will be executed or not
     type: boolean
@@ -153,7 +153,6 @@ steps:
         DOCKERFILE: "<< parameters.dockerfile >>"
         INJECT_AWS_CREDENTIALS: "<< parameters.inject_aws_credentials >>"
         ENABLE_LOAD: "<< parameters.enable_load >>"
-        PLATFORM: "<< parameters.platform >>"
         BUILDER_NAME: "<< parameters.builder_name >>"
         UPDATE_TRACK_FILE: << parameters.update_track_file >>
         ENABLE_PUSH: "<< parameters.enable_push >>"

--- a/src/executors/node/code-test-executor-node-20.yml
+++ b/src/executors/node/code-test-executor-node-20.yml
@@ -17,12 +17,12 @@ docker: # run the steps with Docker
       aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
   - image: postgres:14.3-alpine # PostgresDB service container
     environment:
-      POSTGRES_HOST_AUTH_METHOD: trust  # This is needed to ensure that the PG instance can be accessed locally without explicitly creating credentials
+      POSTGRES_HOST_AUTH_METHOD: trust # This is needed to ensure that the PG instance can be accessed locally without explicitly creating credentials
   - image: localstack/localstack:0.12.2 # Localstack to emulate AWS DynamoDB and S3 services
     environment:
       - EDGE_PORT=8000
       - SERVICES=s3,dynamodb
       - DEFAULT_REGION=us-east-1
       - DEBUG=1
-  - image: circleci/redis:6.2-alpine # Redis service container
-  - image: circleci/mongo:4.4.1 # MongoDB service container
+  - image: cimg/redis:6.2 # Redis service container
+  - image: mongo:4.4.1 # MongoDB service container

--- a/src/jobs/release/release.yml
+++ b/src/jobs/release/release.yml
@@ -36,6 +36,10 @@ parameters:
     description: The SSH key with write permissions to the repository
     type: string
     default: ""
+  pre_release_steps:
+    description: Steps to run before executing the release command
+    type: steps
+    default: []
 steps:
   - add_ssh_keys:
       fingerprints:
@@ -48,6 +52,7 @@ steps:
       yarn_lock_restore_cache_directory: << parameters.working_directory >>
   - attach_workspace:
       at: << parameters.working_directory >>
+  - steps: << parameters.pre_release_steps >>
   - when:
       condition: << parameters.prerelease_version >>
       steps:

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -21,9 +21,13 @@ parameters:
     description: Platform to build the image for
     type: string
     default: linux/amd64
+  node_version:
+    description: Node version
+    type: string
 steps:
   - update_database_track:
       component: "<< parameters.component >>"
       image_repo: "<< parameters.image_repo >>"
       semantic_version: "<< parameters.semantic_version >>"
       image_tag: "<< parameters.image_tag >>"
+      node_version: "<< parameters.node_version >>"

--- a/src/jobs/track/update_database_track.yml
+++ b/src/jobs/track/update_database_track.yml
@@ -26,5 +26,4 @@ steps:
       component: "<< parameters.component >>"
       image_repo: "<< parameters.image_repo >>"
       semantic_version: "<< parameters.semantic_version >>"
-      platform: "<< parameters.platform >>"
       image_tag: "<< parameters.image_tag >>"

--- a/src/jobs/track/update_track.yml
+++ b/src/jobs/track/update_track.yml
@@ -128,7 +128,6 @@ steps:
       kms_key: "<< parameters.kms_key >>"
       inject_aws_credentials: "<< parameters.inject_aws_credentials >>"
       local_registry_container_image: "<< parameters.local_registry_container_image >>"
-      platform: "<< parameters.platform >>"
       enable_dlc: "<< parameters.enable_dlc >>"
       enable_load: "<< parameters.enable_load >>"
       builder_name: "<< parameters.builder_name >>"

--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -13,7 +13,6 @@ echo "BUCKET: ${BUCKET?}"
 echo "LOCAL_REGISTRY: ${LOCAL_REGISTRY?}"
 echo "DOCKERFILE: ${DOCKERFILE?}"
 echo "INJECT_AWS_CREDENTIALS: ${INJECT_AWS_CREDENTIALS?}"
-echo "PLATFORM: ${PLATFORM?}"
 echo "BUILDER_NAME: ${BUILDER_NAME-}"
 echo "EXTRA_BUILD_ARGS: ${EXTRA_BUILD_ARGS[*]}"
 echo "ENABLE_CACHE_TO: ${ENABLE_CACHE_TO:=0}"
@@ -110,9 +109,8 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
   echo "BUILDER_NAME: ${BUILDER_NAME:=buildy-${BRANCH_NAME-}}"
 
   BUILDER_ARGS=(--name "${BUILDER_NAME-}")
-  docker buildx create --use --platform="$PLATFORM" \
+  docker buildx create --use --bootstrap \
     "${BUILDER_ARGS[@]}"
-  docker buildx inspect --bootstrap
 
   OUTPUT_ARGS=()
   if ((ENABLE_PUSH)); then
@@ -162,7 +160,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
     --label "com.datadoghq.tags.git.repository_url=${CIRCLE_REPOSITORY_URL}"
   )
 
-  echo "BUILD_ARGS: ${BUILD_ARGS[*]} $PLATFORM"
+  echo "BUILD_ARGS: ${BUILD_ARGS[*]}"
   docker buildx build \
     "${LEGACY_BUILD_ARGS[@]}" \
     "${DD_TAGS_ARG[@]}" \
@@ -173,7 +171,6 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
     "${BUILD_ARGS[@]}" \
     "${OUTPUT_ARGS[@]}" \
     "${DATADOG_LABELS[@]}" \
-    --platform "$PLATFORM" \
     -f "$BUILD_CONTEXT/$DOCKERFILE" \
     "${TAGS[@]}" \
     "$BUILD_CONTEXT"


### PR DESCRIPTION
# Remove platform parameter and add node_version parameter

This PR makes the following changes:

- Removes the `platform` parameter from track update commands and jobs
  - only removes passing it through so we don't break workflows while deprecating this param
  - rely on native architecture for platform instead of the flag
- Adds `node_version` parameter to database track commands and jobs
- Updates the `extra_build_args` to use the node version parameter
- Adds `pre_release_steps` parameter to the release job
- Updates Docker images in the Node 20 executor:
  - Changes `circleci/redis:6.2-alpine` to `cimg/redis:6.2`
  - Changes `circleci/mongo:4.4.1` to `mongo:4.4.1`
- Simplifies Docker buildx creation by removing platform specification and using `--bootstrap` flag

## Related PRs
- dependency of https://github.com/voiceflow/canvas-export/pull/254
- dependency of https://github.com/voiceflow/database-cli/pull/993