### PR TITLE
feat: GITHUB_TOKEN as build secret (IN-3193)

### DIFF
--- a/src/scripts/track/update_track.sh
+++ b/src/scripts/track/update_track.sh
@@ -160,6 +160,10 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
     --label "com.datadoghq.tags.git.repository_url=${CIRCLE_REPOSITORY_URL}"
   )
 
+  BUILD_SECRETS=(
+    --secret "type=env,id=GITHUB_TOKEN"
+  )
+
   echo "BUILD_ARGS: ${BUILD_ARGS[*]}"
   docker buildx build \
     "${LEGACY_BUILD_ARGS[@]}" \
@@ -169,6 +173,7 @@ if [[ $IMAGE_EXISTS == "false" || "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANC
     "${AWS_CREDENTIALS_ARG[@]}" \
     "${NPM_TOKEN_SECRET[@]}" \
     "${BUILD_ARGS[@]}" \
+    "${BUILD_SECRETS[@]}" \
     "${OUTPUT_ARGS[@]}" \
     "${DATADOG_LABELS[@]}" \
     -f "$BUILD_CONTEXT/$DOCKERFILE" \


### PR DESCRIPTION
### TL;DR

Added GitHub token as a build secret to the track update script. 

### What changed?

Added a new `BUILD_SECRETS` array to the `update_track.sh` script that includes the `GITHUB_TOKEN` as an environment variable secret. This secret is now passed to the `docker buildx build` command. Leaving the build arg in this phase as we move to deprecate it. 

### Why make this change?

This change allows the Docker build process to securely access GitHub resources that require authentication, such as private repositories or packages, without exposing the token in the build arguments or image layers. Using the `--secret` flag ensures the token is only available during build time and not persisted in the final image.