### PR TITLE
feat: write changed files to file not env (IN-1254)

### DIFF
--- a/src/commands/monorepo/set-if-file-changed.yml
+++ b/src/commands/monorepo/set-if-file-changed.yml
@@ -1,7 +1,7 @@
 description: |
   Set the given env var to true if a changed file matches one of the given patterns.
-  The `CHANGED_FILES` environment variable must be set with the `get_changes_files` command prior
-  to running this command.
+  The `CHANGED_FILES_FILE` environment variable (a path to the changed-files list, set by the
+  `get_changed_files` command) must be set prior to running this command.
 parameters:
   file-patterns:
     description: |
@@ -22,7 +22,7 @@ steps:
 
         << parameters.target-env-var >>=false
         for FILE_PATTERN in ${FILE_PATTERNS?}; do
-          if egrep "^.\s+$FILE_PATTERN\$" \<<< "$CHANGED_FILES"; then
+          if egrep "^.\s+$FILE_PATTERN\$" "${CHANGED_FILES_FILE:?}"; then
             << parameters.target-env-var >>=true
             echo "Found $FILE_PATTERN in changed files, setting << parameters.target-env-var >> to true"
             break

--- a/src/commands/monorepo/set-service-data-json.yml
+++ b/src/commands/monorepo/set-service-data-json.yml
@@ -1,7 +1,7 @@
 description: |
   Set the service metadata array in a json file.
-  The `CHANGED_FILES` environment variable must be set with the `get_changes_files` command prior
-  to running this command.
+  The `CHANGED_FILES_FILE` environment variable (a path to the changed-files list, set by the
+  `get_changed_files` command) must be set prior to running this command.
 parameters:
   service-directories:
     description: |
@@ -36,7 +36,7 @@ steps:
 
             echo "Checking if $SERVICE was modified..."
             MODIFIED=false
-            if grep "$DIRECTORY/$SERVICE" \<<< "${CHANGED_FILES?}"; then
+            if grep "$DIRECTORY/$SERVICE" "${CHANGED_FILES_FILE:?}"; then
               MODIFIED=true
             fi
             COMPONENT_NAME=$(jq --raw-output ".serviceName" $DIRECTORY/$SERVICE/package.json)

--- a/src/commands/utils/get_changed_files.yml
+++ b/src/commands/utils/get_changed_files.yml
@@ -1,11 +1,11 @@
 parameters:
-  target_env_var:
-    description: Environment variable to set with the list of changed files
-    type: env_var_name
-    default: CHANGED_FILES
+  target_file:
+    description: Absolute path to write the list of changed files to. Absolute so it survives consumers that set a custom working_directory (e.g. helm).
+    type: string
+    default: /tmp/changed_files.txt
 steps:
   - run:
-      name: Put list of changed files in << parameters.target_env_var >> environment variable
+      name: Write list of changed files to << parameters.target_file >>
       command: |
        if [[ -z $COMPUTED_BASE_REVISION  ]]; then
           BASE_REVISION="master"
@@ -19,5 +19,5 @@ steps:
        if [[ $BASE == $CIRCLE_SHA1 ]]; then
           BASE="$(git rev-parse HEAD~1)"
        fi
-       FILE_CHANGES="$(git diff --name-status --no-commit-id -r $BASE...$CIRCLE_SHA1)"
-       echo "export << parameters.target_env_var >>=\"$FILE_CHANGES\"" >> "$BASH_ENV"
+       git diff --name-status --no-commit-id -r $BASE...$CIRCLE_SHA1 > "<< parameters.target_file >>"
+       echo "export CHANGED_FILES_FILE=\"<< parameters.target_file >>\"" >> "$BASH_ENV"

--- a/src/scripts/helm/get_modified_charts.sh
+++ b/src/scripts/helm/get_modified_charts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Expected environment variables:
-echo "CHANGED_FILES: ${CHANGED_FILES?}"
+echo "CHANGED_FILES_FILE: ${CHANGED_FILES_FILE:?}"
 echo "CHART_DIR: ${CHART_DIR:?}"
 echo "MODIFIED_CHARTS_ENV: ${MODIFIED_CHARTS_ENV:?}"
 
@@ -26,7 +26,7 @@ done
 # Extract only modified charts
 MODIFIED_CHARTS=()
 for CHART in "${ALL_CHARTS[@]}"; do
-    if grep -q -oP "(M|A)\s*${CHART_DIR}${CHART}/${CHART}/.*" <<< "${CHANGED_FILES?}"; then
+    if grep -q -oP "(M|A)\s*${CHART_DIR}${CHART}/${CHART}/.*" "${CHANGED_FILES_FILE:?}"; then
     MODIFIED_CHARTS+=("$CHART")
     fi;
 done


### PR DESCRIPTION
### TL;DR

Replaces the `CHANGED_FILES` environment variable (which stored file contents inline) with `CHANGED_FILES_FILE`, a path to a file containing the list of changed files.

### What changed?

The `get_changed_files` command no longer stores the git diff output in a `CHANGED_FILES` environment variable. Instead, it writes the output directly to a file (defaulting to `/tmp/changed_files.txt`) and exports `CHANGED_FILES_FILE` pointing to that path. All consumers (`set-if-file-changed`, `set-service-data-json`, and `get_modified_charts.sh`) have been updated to read from the file path rather than the inline environment variable.

### How to test?

Run a pipeline that uses the `get_changed_files` command followed by any of the dependent commands (`set-if-file-changed`, `set-service-data-json`, or helm chart detection). Verify that changed files are correctly detected and the appropriate environment variables are set as expected.

### Why make this change?

Storing large amounts of file change data inline in an environment variable is fragile — it can break with special characters, newlines, or when the diff is large. Writing to a file is more robust. Additionally, using an absolute path (`/tmp/changed_files.txt`) ensures the file remains accessible to consumers that set a custom `working_directory` (e.g. helm jobs), where a relative path would not survive the directory change.