### PR TITLE
feat:  removed e2e default [pre-release]

### DIFF
--- a/src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml
+++ b/src/commands/vfcli/vfcli-create-or-get-free-env-from-pool.yml
@@ -14,8 +14,10 @@ parameters:
     default: 1h
   node-group:
     type: string
-    description: Name of the node group to use
-    default: "e2e"
+    description: |
+      Name of the node group to pin the environment to. Leave empty (default) to use
+      vfcli's capacity-type scheduling: non-dev envs (test-/review-/e2e-) default to spot.
+    default: ""
   force:
     type: boolean
     description: Whether to force environment creation without checking for free environment


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements IN-4087**

### Brief description. What is this change?

Stop e2e envs from using default nodegroup flag of e2e

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test