### PR TITLE
fix: resolve source PR on graphite mq branches (IN-4269)

### DIFF
--- a/src/commands/monorepo/monorepo_save_cache.yml
+++ b/src/commands/monorepo/monorepo_save_cache.yml
@@ -61,7 +61,7 @@ steps:
                     << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-<< parameters.cache_branch >>--{{ .Revision }}
                     <</ parameters.cache_branch >>
                     <<^ parameters.cache_branch >>
-                    << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}"
+                    << parameters.cache_identifier >>--{{ .Environment.CACHE_VERSION }}-{{ .Branch }}--{{ .Revision }}
                     <</ parameters.cache_branch >>
         - when:
             condition:

--- a/src/commands/utils/set-pr-branch.yml
+++ b/src/commands/utils/set-pr-branch.yml
@@ -23,6 +23,6 @@ steps:
 
         API_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${<< parameters.pr_number_env_var >>:?}"
         RESPONSE=$(curl -s -H "Authorization: token ${GITHUB_TOKEN:?}" "${API_URL}")
-        PR_BRANCH=$(echo "${RESPONSE:?}" | jq -r '.head.ref')
+        PR_BRANCH=$(echo "${RESPONSE:?}" | jq -r '.head.ref // empty')
 
         echo "export << parameters.target_env_var >>=\"${PR_BRANCH}\"" >> "$BASH_ENV"

--- a/src/commands/utils/set-pr-number.yml
+++ b/src/commands/utils/set-pr-number.yml
@@ -12,15 +12,13 @@ steps:
       name: Set << parameters.target_env_var >> variable with the PR number
       working_directory: << parameters.working_directory >>
       command: |
-        # If multiple PRs are merged at the same time, CIRCLE_PULL_REQUEST will
-        # be a random one of them. We need to get the PR number from the URL.
-        PR="${CIRCLE_PULL_REQUEST##*/}"
-
-        # If this is a bors branch, CIRCLE_PULL_REQUEST will be empty. We need
-        # to get the PR number from the commit message (e.g. "fix: bug (CT-000) (#1234)")
-        PR="${PR:-$(git log --format=oneline -n 1 $CIRCLE_SHA1  | grep --only-matching --extended-regexp '#[0-9]+' || echo '')}"
-
-        # Trim leading # from PR number
-        PR="${PR##\#}"
+        # Graphite merge-queue branches carry their own draft PR, so CIRCLE_PULL_REQUEST points at
+        # the draft rather than at the PR being merged. The tip commit is the top-of-stack squash,
+        # whose subject ends in "(#<PR>)".
+        if [[ "${CIRCLE_BRANCH}" =~ ^gtmq_ ]]; then
+          PR=$(git log -1 --format=%s "${CIRCLE_SHA1}" | sed -nE 's/.*\(#([0-9]+)\)[[:space:]]*$/\1/p')
+        else
+          PR="${CIRCLE_PULL_REQUEST##*/}"
+        fi
 
         echo "export << parameters.target_env_var >>=\"${PR}\"" >> "$BASH_ENV"


### PR DESCRIPTION
## Description

Three independent fixes to how the orb resolves the source PR and builds the turborepo cache key.

1. **`set-pr-number`** **resolves the source PR on** **`gtmq_`** **branches.** On a Graphite merge-queue branch it now reads the tip commit's subject and takes the trailing `(#N)`, instead of trusting `CIRCLE_PULL_REQUEST`. Every other branch keeps the existing `CIRCLE_PULL_REQUEST` path.
2. **Drop a stray** **`"`** **from the turbo save key** in the `<<^ parameters.cache_branch >>` arm of `monorepo_save_cache`.
3. **Guard against a** **`null`** **PR branch** in `set-pr-branch` (`.head.ref // empty`).

## Testing

Pushed a branch ( ) off of the following PR ( https://app.graphite.com/github/pr/voiceflow/platform/3841 ) that references this dev orb.

The [render-config](https://app.circleci.com/pipelines/github/voiceflow/platform/68850/workflows/1a00278c-28ed-48a1-bd69-f47bae412b91/jobs/431634) job shows the correct `pr-branch` in `cat values.json` step: `pr_branch": "ogrady/mq-turbo-cache-reuse/IN-4280"`

And [build](https://app.circleci.com/pipelines/github/voiceflow/platform/68850/workflows/a0078b4c-92fa-4e31-9701-e1464eeb25e0/jobs/431675) job shows the branch key found:

```
No cache is found for key: monorepo-build-cache--11-25-2025-gtmq_test/IN-4280--4032ceaab731236844248ddff7cfb1398bdba22c
Found a cache from job 431586 (https://app.circleci.com/workflow/924fadf9-2a0e-404d-8e2d-910edf09e941/job/d098ea39-80b4-4d05-bee8-a89eb03e36fb) at monorepo-build-cache--11-25-2025-ogrady/mq-turbo-cache-reuse/IN-4280-
```

And the build step takes 2s with full cache hit: `Time:    896ms >>> FULL TURBO`